### PR TITLE
TT-10137 refactor: Remove TYK_GW_OPTIMISATIONSUSEASYNCSESSIONWRITE setting

### DIFF
--- a/components/tyk-gateway/templates/deployment-gw-repset.yaml
+++ b/components/tyk-gateway/templates/deployment-gw-repset.yaml
@@ -143,8 +143,6 @@ spec:
             value: "/mnt/tyk-gateway/policies"
           - name: TYK_GW_STORAGE_MAXIDLE
             value: "1000"
-          - name: TYK_GW_OPTIMISATIONSUSEASYNCSESSIONWRITE
-            value: "true"
           - name: TYK_GW_ENABLENONTRANSACTIONALRATELIMITER
             value: "true"
           - name: TYK_GW_POLICIES_POLICYSOURCE


### PR DESCRIPTION
I believe this is obsolete, see https://github.com/TykTechnologies/tyk-docs/issues/3279
