### PR TITLE
TT-10640 add support for pdb resource for gateway component

### DIFF
--- a/components/tyk-gateway/templates/pdb-gw.yaml
+++ b/components/tyk-gateway/templates/pdb-gw.yaml
@@ -1,7 +1,7 @@
-{{- if and .Values.gateway.minAvailable .Values.gateway.maxUnavailable }}
-{{- print "If gateway.minAvailable and gateway.maxUnavailable are set at the same time, minAvailable takes precedence." }}
+{{- if and .Values.gateway.pdb .Values.gateway.pdb.enabled }}
+{{- if and .Values.gateway.pdb.minAvailable .Values.gateway.pdb.maxUnavailable }}
+{{- print "If gateway.pdb.minAvailable and gateway.pdb.maxUnavailable are set at the same time, minAvailable takes precedence." }}
 {{- end }}
-{{- if or .Values.gateway.minAvailable .Values.gateway.maxUnavailable }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -12,10 +12,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  {{- if .Values.gateway.minAvailable }}
-  minAvailable: {{ .Values.gateway.minAvailable }}
-  {{- else if .Values.gateway.maxUnavailable }}
-  maxUnavailable: {{ .Values.gateway.maxUnavailable }}
+  {{- if .Values.gateway.pdb.minAvailable }}
+  minAvailable: {{ .Values.gateway.pdb.minAvailable }}
+  {{- else if .Values.gateway.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.gateway.pdb.maxUnavailable }}
   {{- end }}
   selector:
     matchLabels:

--- a/components/tyk-gateway/templates/pdb-gw.yaml
+++ b/components/tyk-gateway/templates/pdb-gw.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.gateway.minAvailable .Values.gateway.maxUnavailable }}
+{{- print "If gateway.minAvailable and gateway.maxUnavailable are set at the same time, minAvailable takes precedence." }}
+{{- end }}
+{{- if or .Values.gateway.minAvailable .Values.gateway.maxUnavailable }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: gateway-{{ include "tyk-gateway.fullname" . }}
+  labels:
+    app: gateway-{{ include "tyk-gateway.fullname" . }}
+    chart: {{ include "tyk-gateway.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  {{- if .Values.gateway.minAvailable }}
+  minAvailable: {{ .Values.gateway.minAvailable }}
+  {{- else if .Values.gateway.maxUnavailable }}
+  maxUnavailable: {{ .Values.gateway.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: gateway-{{ include "tyk-gateway.fullname" . }}
+      release: {{ .Release.Name }}
+{{- end}}

--- a/components/tyk-gateway/values.yaml
+++ b/components/tyk-gateway/values.yaml
@@ -149,6 +149,12 @@ gateway:
   # replicaCount specifies number of replicas to be created if kind is Deployment.
   replicaCount: 1
 
+  # minAvailable and maxUnavailable configure thresholds for PodDisruptionBudget resource
+  # per PodDisruptionBudget spec they are mutually exclusive, but this chart allows
+  # setting them both, in which case minAvailable will take precedence
+  minAvailable: ""
+  maxUnavailable: ""
+
   # autoscaling configuration if kind IS NOT DaemonSet
   autoscaling: {}
   #  enabled: true

--- a/components/tyk-gateway/values.yaml
+++ b/components/tyk-gateway/values.yaml
@@ -149,11 +149,14 @@ gateway:
   # replicaCount specifies number of replicas to be created if kind is Deployment.
   replicaCount: 1
 
-  # minAvailable and maxUnavailable configure thresholds for PodDisruptionBudget resource
-  # per PodDisruptionBudget spec they are mutually exclusive, but this chart allows
-  # setting them both, in which case minAvailable will take precedence
-  minAvailable: ""
-  maxUnavailable: ""
+  # PodDisruptionBudget configuration
+  pdb:
+    enabled: false
+    # minAvailable and maxUnavailable configure thresholds for PodDisruptionBudget resource
+    # per PodDisruptionBudget spec they are mutually exclusive, but this chart allows
+    # setting them both, in which case minAvailable will take precedence
+    minAvailable: ""
+    maxUnavailable: ""
 
   # autoscaling configuration if kind IS NOT DaemonSet
   autoscaling: {}

--- a/tyk-mdcb-data-plane/values.yaml
+++ b/tyk-mdcb-data-plane/values.yaml
@@ -161,6 +161,12 @@ tyk-gateway:
     # replicaCount specifies number of replicas to be created if kind is Deployment.
     replicaCount: 1
 
+    # minAvailable and maxUnavailable configure thresholds for PodDisruptionBudget resource
+    # per PodDisruptionBudget spec they are mutually exclusive, but this chart allows
+    # setting them both, in which case minAvailable will take precedence
+    minAvailable: ""
+    maxUnavailable: ""
+
     # autoscaling configuration if kind IS NOT DaemonSet
     autoscaling: {}
     #  enabled: true

--- a/tyk-mdcb-data-plane/values.yaml
+++ b/tyk-mdcb-data-plane/values.yaml
@@ -161,11 +161,14 @@ tyk-gateway:
     # replicaCount specifies number of replicas to be created if kind is Deployment.
     replicaCount: 1
 
-    # minAvailable and maxUnavailable configure thresholds for PodDisruptionBudget resource
-    # per PodDisruptionBudget spec they are mutually exclusive, but this chart allows
-    # setting them both, in which case minAvailable will take precedence
-    minAvailable: ""
-    maxUnavailable: ""
+    # PodDisruptionBudget configuration
+    pdb:
+      enabled: false
+      # minAvailable and maxUnavailable configure thresholds for PodDisruptionBudget resource
+      # per PodDisruptionBudget spec they are mutually exclusive, but this chart allows
+      # setting them both, in which case minAvailable will take precedence
+      minAvailable: ""
+      maxUnavailable: ""
 
     # autoscaling configuration if kind IS NOT DaemonSet
     autoscaling: {}

--- a/tyk-oss/values.yaml
+++ b/tyk-oss/values.yaml
@@ -133,11 +133,14 @@ tyk-gateway:
     # replicaCount specifies number of replicas to be created if kind is Deployment.
     replicaCount: 1
 
-    # minAvailable and maxUnavailable configure thresholds for PodDisruptionBudget resource
-    # per PodDisruptionBudget spec they are mutually exclusive, but this chart allows
-    # setting them both, in which case minAvailable will take precedence
-    minAvailable: ""
-    maxUnavailable: ""
+    # PodDisruptionBudget configuration
+    pdb:
+      enabled: false
+      # minAvailable and maxUnavailable configure thresholds for PodDisruptionBudget resource
+      # per PodDisruptionBudget spec they are mutually exclusive, but this chart allows
+      # setting them both, in which case minAvailable will take precedence
+      minAvailable: ""
+      maxUnavailable: ""
 
     # autoscaling configuration if kind IS NOT DaemonSet
     autoscaling: {}

--- a/tyk-oss/values.yaml
+++ b/tyk-oss/values.yaml
@@ -133,6 +133,12 @@ tyk-gateway:
     # replicaCount specifies number of replicas to be created if kind is Deployment.
     replicaCount: 1
 
+    # minAvailable and maxUnavailable configure thresholds for PodDisruptionBudget resource
+    # per PodDisruptionBudget spec they are mutually exclusive, but this chart allows
+    # setting them both, in which case minAvailable will take precedence
+    minAvailable: ""
+    maxUnavailable: ""
+
     # autoscaling configuration if kind IS NOT DaemonSet
     autoscaling: {}
     #  enabled: true

--- a/tyk-single-dc/values.yaml
+++ b/tyk-single-dc/values.yaml
@@ -243,11 +243,14 @@ tyk-gateway:
     # replicaCount specifies number of replicas to be created if kind is Deployment.
     replicaCount: 1
 
-    # minAvailable and maxUnavailable configure thresholds for PodDisruptionBudget resource
-    # per PodDisruptionBudget spec they are mutually exclusive, but this chart allows
-    # setting them both, in which case minAvailable will take precedence
-    minAvailable: ""
-    maxUnavailable: ""
+    # PodDisruptionBudget configuration
+    pdb:
+      enabled: false
+      # minAvailable and maxUnavailable configure thresholds for PodDisruptionBudget resource
+      # per PodDisruptionBudget spec they are mutually exclusive, but this chart allows
+      # setting them both, in which case minAvailable will take precedence
+      minAvailable: ""
+      maxUnavailable: ""
 
     # autoscaling configuration if kind IS NOT DaemonSet
     autoscaling: {}

--- a/tyk-single-dc/values.yaml
+++ b/tyk-single-dc/values.yaml
@@ -243,6 +243,12 @@ tyk-gateway:
     # replicaCount specifies number of replicas to be created if kind is Deployment.
     replicaCount: 1
 
+    # minAvailable and maxUnavailable configure thresholds for PodDisruptionBudget resource
+    # per PodDisruptionBudget spec they are mutually exclusive, but this chart allows
+    # setting them both, in which case minAvailable will take precedence
+    minAvailable: ""
+    maxUnavailable: ""
+
     # autoscaling configuration if kind IS NOT DaemonSet
     autoscaling: {}
     #  enabled: true


### PR DESCRIPTION
## Description
As described in #140 having built-in support for `PodDisruptionBudget` resource will reduce the amount of post-deployment work need to achieve fully highly-available solution.

### Testing procedure for the changes:

1. Deploy single node `minikube` cluster
2. Deploy postgresql and redis (I found issues when deploying redis on non-control plane nodes)
3. Add a second node to the cluster and label it with `service=tyk-gateway`
4. Deploy Tyk Gateway with appropriate node selector, `gateway.replicaCount` set to 2, `gateway.pdb.enabled` set to `true` and `gateway.pdb.minAvailable` or `gateway.pdb.maxUnavailable` set to 1
5. Add a third node to `minikube` cluster and label it with `service=tyk-gateway`
6. Drain the second node and observe as Tyk Gateway pods are drained and rescheduled to the third node, one a time
7. Un-cordon second cluster node
8. Delete `PodDisruptionBudget` deployed by Tyk Gateway chart
9. Drain the third node and observe as Tyk Gateway pods are drained and rescheduled to the second node, all at once

## Related Issue
#140 

## Motivation and Context
It eliminates the need for manual creation of PDB resources in environments with high requirements for HA.

## Test Coverage For This Change

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] Documentation updates or improvements.


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [X] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
     - [ ] I have manually updated the README(s)/documentation accordingly.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.