### PR TITLE
correctly setting the gateway host and port in the dashboard helm chart

### DIFF
--- a/components/tyk-dashboard/templates/_helpers.tpl
+++ b/components/tyk-dashboard/templates/_helpers.tpl
@@ -52,7 +52,7 @@ http
 {{- end -}}
 
 {{- define "tyk-dashboard.gateway_host" -}}
-gateway-svc-{{.Release.Name}}-tyk-gateway.{{ .Release.Namespace }}.svc.cluster.local
+{{ include "tyk-dashboard.gwproto" . }}://gateway-svc-{{.Release.Name}}-tyk-gateway.{{ .Release.Namespace }}.svc.cluster.local
 {{- end -}}
 
 {{- define "tyk-dashboard.gateway_url" -}}

--- a/components/tyk-dashboard/templates/deployment-dashboard.yaml
+++ b/components/tyk-dashboard/templates/deployment-dashboard.yaml
@@ -113,9 +113,9 @@ spec:
             value: "128"
           - name: TYK_DB_TYKAPI_HOST
             # this needs to be setup from values
-            value: {{ include "tyk-dashboard.gateway_url" .}}
+            value: {{ include "tyk-dashboard.gateway_host" .}}
           - name: TYK_DB_TYKAPI_PORT
-            value: "{{ .Values.global.servicePorts.dashboard }}"
+            value: "{{ .Values.global.servicePorts.gateway }}"
           - name: TYK_DB_TYKAPI_SECRET
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
PR Tested with self-managed deployment with @caroltyk @letzya 

```
Failed to save new session object to Tyk: Failed to create key: Post "http://gateway-svc-tyk-stack-tyk-gateway.tyk.svc.cluster.local:8080:3000/tyk/keys/create": dial tcp: lookup gateway-svc-tyk-stack-tyk-gateway.tyk.svc.cluster.local:8080: no such host
```

From the deployed dashboard instance, `TYK_DB_TYKAPI_HOST` and `TYK_DB_TYKAPI_PORT` are incorrectly set:

```
env | grep TYK_DB_TYK
TYK_DB_TYKAPI_HOST=http://gateway-svc-tyk-stack-tyk-gateway.tyk.svc.cluster.local:8080/
TYK_DB_TYKAPI_SECRET=CHANGEME
TYK_DB_TYKAPI_PORT=3000
```

This PR resolves that by correctly setting the gateway host and port