### PR TITLE
TT-12021 Deprecate dashboard.hashKeys

### DIFF
--- a/components/tyk-dashboard/templates/deployment-dashboard.yaml
+++ b/components/tyk-dashboard/templates/deployment-dashboard.yaml
@@ -75,12 +75,8 @@ spec:
             value: "{{ .Values.dashboard.defaultPageSize }}"
           - name: "TYK_DB_NOTIFYONCHANGE"
             value: "{{ .Values.dashboard.notifyOnChange }}"
-          - name: "TYK_DB_HASHKEYS"            
-          {{- if .Values.dashboard.hashKeys }}
-            value: {{ .Values.dashboard.hashKeys | quote }}
-          {{- else }}   
-            value: {{ .Values.global.hashKeys | quote }}         
-          {{- end }}   
+          - name: "TYK_DB_HASHKEYS"
+            value: {{ .Values.global.hashKeys | quote }}
           - name: "TYK_DB_ENABLEDUPLICATESLUGS"
             value: "{{ .Values.dashboard.enableDuplicateSlugs }}"
           - name: "TYK_DB_SHOWORGID"

--- a/components/tyk-dashboard/values.yaml
+++ b/components/tyk-dashboard/values.yaml
@@ -202,11 +202,8 @@ dashboard:
   # notifyOnChange specifies whether the Tyk Dashboard will notify all Tyk Gateway nodes to hot-reload when an API definition is changed.
   # It is used to set TYK_DB_NOTIFYONCHANGE
   notifyOnChange: true
-  # hashKeys is used to enable/disable key hashing. It should match with the value set in Gateway configuration.
-  # The Dashboard will now operate in a mode that is compatible with key hashing.
-  # It is used to set TYK_DB_HASHKEYS
   # Deprecated:
-  #   This will be deprecated in future and will be replaced with .global.hashKeys
+  #   This field is deprecated in from v1.4.0, please set `global.hashKeys` for configuring hash keys feature
   hashKeys: true
   # enableDuplicateSlugs configures the dashboard whether validate against other listen paths.
   # Setting this option to true will cause the dashboard to NOT validate against other listen paths.

--- a/components/tyk-gateway/values.yaml
+++ b/components/tyk-gateway/values.yaml
@@ -463,10 +463,6 @@ gateway:
       # all the subsequent work that operation causes
       parentBased: false
 
-  # hashKeys is used to enable/disable key hashing.
-  # It is used to set TYK_GW_HASHKEYS
-  hashKeys: true
-
   # serviceAccountName field indicates the name of the Service Account that is going to be used by the Pods.
   # If a service account is to be used for Tyk Gateway, it should be manually created
   serviceAccountName: ""

--- a/tyk-control-plane/values.yaml
+++ b/tyk-control-plane/values.yaml
@@ -228,10 +228,11 @@ global:
     # It is used to set TYK_MDCB_SECURITY_PRIVATECERTIFICATEENCODINGSECRET
     privateCertificateEncodingSecret: ""
 
-  # hashKeys specifies that if your Tyk Gateway is using hashed keys, set this value to true, so it matches.
-  # The Dashboard will now operate in a mode that is compatible with key hashing.
-  # It will enable hash keys for Tyk Gateway
-  # It is used to set TYK_GW_HASHKEYS
+  # hashKeys specifies that if your Tyk Gateway is using hashed keys, set this value to true so it matches.
+  # The Dashboard and MDCB will now operate in a mode that is compatible with key hashing.
+  # This takes precedence over the dashboard value i.e `dashboard.hashKeys`
+  # It is used to set TYK_DB_HASHKEYS and TYK_MDCB_HASHKEYS
+  # It will enable hashkeys in both mdcb and dashboard.
   hashKeys: true
 
   # Enables validation of examples in the OAS spec. Defaults to false.

--- a/tyk-control-plane/values.yaml
+++ b/tyk-control-plane/values.yaml
@@ -228,11 +228,9 @@ global:
     # It is used to set TYK_MDCB_SECURITY_PRIVATECERTIFICATEENCODINGSECRET
     privateCertificateEncodingSecret: ""
 
-  # hashKeys specifies that if your Tyk Gateway is using hashed keys, set this value to true so it matches.
-  # The Dashboard and MDCB will now operate in a mode that is compatible with key hashing.
-  # This takes precedence over the dashboard value i.e `dashboard.hashKeys`
-  # It is used to set TYK_DB_HASHKEYS and TYK_MDCB_HASHKEYS
-  # It will enable hashkeys in both mdcb and dashboard.
+  # hashKeys specifies if your Tyk Control Plane is using hashed keys.
+  # It is used to set TYK_GW_HASHKEYS, TYK_DB_HASHKEYS and TYK_MDCB_HASHKEYS
+  # When set to true, Dashboard, MDCB, and management gateway will operate in a mode that is compatible with key hashing.
   hashKeys: true
 
   # Enables validation of examples in the OAS spec. Defaults to false.
@@ -814,12 +812,8 @@ tyk-dashboard:
     # notifyOnChange specifies whether the Tyk Dashboard will notify all Tyk Gateway nodes to hot-reload when an API definition is changed.
     # It is used to set TYK_DB_NOTIFYONCHANGE
     notifyOnChange: true
-    # hashKeys specifies that if your Tyk Gateway is using hashed keys, set this value to true, so it matches.
-    # The Dashboard will now operate in a mode that is compatible with key hashing.
-    # It is used to set TYK_DB_HASHKEYS
-    #
     # Deprecated:
-    #   This field will be deprecated in the next release, please set `global.hashKeys` for configuring hash keys feature
+    #   This field is deprecated in from v1.4.0, please set `global.hashKeys` for configuring hash keys feature
     #     of Tyk Dashboard.
     hashKeys: true
     # enableDuplicateSlugs configures the dashboard whether validate against other listen paths.

--- a/tyk-control-plane/values.yaml
+++ b/tyk-control-plane/values.yaml
@@ -229,7 +229,7 @@ global:
     privateCertificateEncodingSecret: ""
 
   # hashKeys specifies if your Tyk Control Plane is using hashed keys.
-  # It is used to set TYK_GW_HASHKEYS, TYK_DB_HASHKEYS and TYK_MDCB_HASHKEYS
+  # It is used to set TYK_GW_HASHKEYS, TYK_DB_HASHKEYS, TYK_MDCB_HASHKEYS and TYK_MDCB_SYNCWORKER_HASHKEYS
   # When set to true, Dashboard, MDCB, and management gateway will operate in a mode that is compatible with key hashing.
   hashKeys: true
 

--- a/tyk-stack/values.yaml
+++ b/tyk-stack/values.yaml
@@ -218,10 +218,9 @@ global:
   # Choose the storageType for Tyk. [ "mongo", "postgres" ]
   storageType: &globalStorageType postgres
 
-  # hashKeys specifies that if your Tyk Gateway is using hashed keys, set this value to true, so it matches.
-  # The Dashboard will now operate in a mode that is compatible with key hashing.
-  # It will enable hash keys for Tyk Gateway
-  # It is used to set TYK_GW_HASHKEYS
+  # hashKeys specifies if your Tyk Gateway and Dashboard is using hashed keys.
+  # It is used to set TYK_GW_HASHKEYS and TYK_DB_HASHKEYS
+  # When set to true, Dashboard and gateway will operate in a mode that is compatible with key hashing.
   hashKeys: true
 
   # Enables validation of examples in the OAS spec. Defaults to false.
@@ -799,13 +798,8 @@ tyk-dashboard:
     # notifyOnChange specifies whether the Tyk Dashboard will notify all Tyk Gateway nodes to hot-reload when an API definition is changed.
     # It is used to set TYK_DB_NOTIFYONCHANGE
     notifyOnChange: true
-    # hashKeys specifies that if your Tyk Gateway is using hashed keys, set this value to true, so it matches.
-    # The Dashboard will now operate in a mode that is compatible with key hashing.
-    # It is used to set TYK_DB_HASHKEYS
-    #
     # Deprecated:
-    #   This field will be deprecated in the next release, please set `global.hashKeys` for configuring hash keys feature
-    #     of Tyk Dashboard.
+    #   This field is deprecated in from v1.4.0, please set `global.hashKeys` for configuring hash keys feature
     hashKeys: true
     # enableDuplicateSlugs configures the dashboard whether validate against other listen paths.
     # Setting this option to true will cause the dashboard to NOT validate against other listen paths.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

dashboard.hashKeys is deprecated now. Users should use `global.hashKeys` field to set key hashing instead.

The global.hashKeys will help to ensure configuration alignment between gateway, dashboard, and MDCB components.

## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## Test Coverage For This Change
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->

dashboard.hashKeys is deprecated so setting it will not affect the hashKeys configuration. Dashboard will take the hashkey configuration value from global.hashKeys field only.

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] Documentation updates or improvements.


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [ ] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
     - [ ] I have manually updated the README(s)/documentation accordingly.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.