### PR TITLE
[TT-12321] Fix MDCB HealthCheck Port settings

### DIFF
--- a/components/tyk-mdcb/templates/_helpers.tpl
+++ b/components/tyk-mdcb/templates/_helpers.tpl
@@ -162,3 +162,14 @@ HTTP Protocol that is used by Tyk MDCB. At the moment, TLS is not supported.
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{/*
+HealthCheckPort will take precedence to avoid breaking change
+*/}}
+{{- define "mdcb.healthCheckPort" }}
+{{- if .Values.mdcb.probes.healthCheckPort -}}
+{{ .Values.mdcb.probes.healthCheckPort }}
+{{- else -}}
+{{ .Values.mdcb.probes.httpPort }}
+{{- end }}
+{{- end -}}

--- a/components/tyk-mdcb/templates/deployment-mdcb.yaml
+++ b/components/tyk-mdcb/templates/deployment-mdcb.yaml
@@ -38,12 +38,12 @@ spec:
           imagePullPolicy: {{ .Values.mdcb.image.pullPolicy }}
           command: ["/opt/tyk-sink/tyk-sink", "--c=/etc/tyk-sink/tyk_mdcb.conf"]
           ports:
-            - containerPort: {{ .Values.mdcb.listenPort }}
-            - containerPort: {{ if .Values.mdcb.probes.httpPort }}{{ .Values.mdcb.probes.httpPort }}{{ else }}{{ .Values.mdcb.probes.healthCheckPort }}{{ end }}
+          - containerPort: {{ .Values.mdcb.listenPort }}
+          - containerPort: {{ include "mdcb.healthCheckPort" . }}
           livenessProbe:
             httpGet:
               path: {{ .Values.mdcb.probes.liveness.path }}
-              port: {{ if .Values.mdcb.probes.httpPort }}{{ .Values.mdcb.probes.httpPort }}{{ else }}{{ .Values.mdcb.probes.healthCheckPort }}{{ end }}
+              port: {{ include "mdcb.healthCheckPort" . }}
               scheme: {{ if .Values.mdcb.httpServerOptions.useSSL }}HTTPS{{ else }}HTTP{{ end }}
             initialDelaySeconds: {{ .Values.mdcb.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.mdcb.probes.liveness.periodSeconds }}
@@ -56,7 +56,7 @@ spec:
             failureThreshold: {{ .Values.mdcb.probes.readiness.failureThreshold }}
             httpGet:
               path: {{ .Values.mdcb.probes.readiness.path }}
-              port: {{ if .Values.mdcb.probes.httpPort }}{{ .Values.mdcb.probes.httpPort }}{{ else }}{{ .Values.mdcb.probes.healthCheckPort }}{{ end }}
+              port: {{ include "mdcb.healthCheckPort" . }}
               scheme: {{ if .Values.mdcb.httpServerOptions.useSSL }}HTTPS{{ else }}HTTP{{ end }}
           resources:
             {{- toYaml .Values.mdcb.resources | nindent 12 }}
@@ -82,10 +82,10 @@ spec:
             {{- $version := regexReplaceAll "^v" .Values.mdcb.image.tag "" }}
             {{- if  semverCompare ">=2.6.0" $version }}
             - name: TYK_MDCB_HTTPPORT
-              value: "{{ .Values.mdcb.probes.healthCheckPort }}"
+              value: {{ include "mdcb.healthCheckPort" . | quote }}
             {{- else }}
             - name: TYK_MDCB_HEALTHCHECKPORT
-              value: "{{ .Values.mdcb.probes.healthCheckPort }}"
+              value: {{ include "mdcb.healthCheckPort" . | quote }}
             {{- end }}
             - name: TYK_MDCB_LISTENPORT
               value: "{{ .Values.mdcb.listenPort }}"

--- a/components/tyk-mdcb/values.yaml
+++ b/components/tyk-mdcb/values.yaml
@@ -208,11 +208,13 @@ mdcb:
     # This port lets MDCB allow standard health checks.
     # It also defines the path for liveness and readiness probes.
     # It is used to set TYK_MDCB_HEALTHCHECKPORT and TYK_MDCB_HTTPPORT when mdcb >= v2.6.0
-    healthCheckPort: 8181
+    # This field will be deprecated in upcoming release. Use `httpPort` instead.
+    # healthCheckPort: 8181
     
     # This is the preferred port setting for MDCB >= v2.6.0.
     # Users should use httpPort instead of healthCheckPort for newer versions.
-    # httpPort: 8181
+    httpPort: 8181
+
     # liveness includes details about liveness probe used in MDCB Deployment.
     liveness:
       # path represents the http path to be used in liveness probe in MDBC deployment.

--- a/tyk-control-plane/values.yaml
+++ b/tyk-control-plane/values.yaml
@@ -1227,12 +1227,13 @@ tyk-mdcb:
       # This port lets MDCB allow standard health checks.
       # It also defines the path for liveness and readiness probes.
       # It is used to set TYK_MDCB_HEALTHCHECKPORT and TYK_MDCB_HTTPPORT when mdcb >= v2.6.0
-      healthCheckPort: 8181
+      # This field will be deprecated in upcoming release. Use `httpPort` instead.
+      # healthCheckPort: 8181
 
       # This is the preferred port setting for MDCB >= v2.6.0.
       # Users should use httpPort instead of healthCheckPort for newer versions.
       # This value is used to set TYK_MDCB_HTTPPORT when MDCB is >= 2.6.0.
-      # httpPort: 8181
+      httpPort: 8181
       # liveness includes details about liveness probe used in MDCB Deployment.
       liveness:
         # path represents the http path to be used in liveness probe in MDBC deployment.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- For backward compatibility, if both httpPort and healthCheckPort are set, healthCheckPort will take precedence.
- Enable setting of `httpPort` by default.

## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->
[TT-12321](https://tyktech.atlassian.net/browse/TT-12321)

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## Test Coverage For This Change
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] Documentation updates or improvements.


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
     - [ ] I have manually updated the README(s)/documentation accordingly.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[TT-12321]: https://tyktech.atlassian.net/browse/TT-12321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ