### PR TITLE
Add optional extraVolumes and extraVolumeMounts to bootstrap jobs

### DIFF
--- a/components/tyk-bootstrap/templates/bootstrap-post-install.yaml
+++ b/components/tyk-bootstrap/templates/bootstrap-post-install.yaml
@@ -107,6 +107,14 @@ spec:
            {{- if .Values.bootstrap.jobs.postInstall.extraEnvs }}
            {{- include "tyk-bootstrap.tplvalues.render" ( dict "value" .Values.bootstrap.jobs.postInstall.extraEnvs "context" $ ) | nindent 12 }}
            {{- end }}
+          {{- if .Values.bootstrap.extraVolumeMounts }}
+          volumeMounts:
+            {{- include "tyk-bootstrap.tplvalues.render" (dict "value" .Values.bootstrap.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+      {{- if .Values.bootstrap.extraVolumes }}
+      volumes:
+        {{- include "tyk-bootstrap.tplvalues.render" (dict "value" .Values.bootstrap.extraVolumes "context" $) | nindent 8 }}
+      {{- end }}
       restartPolicy: Never
       terminationGracePeriodSeconds: 0
 {{- end }}

--- a/components/tyk-bootstrap/templates/bootstrap-pre-delete.yaml
+++ b/components/tyk-bootstrap/templates/bootstrap-pre-delete.yaml
@@ -53,6 +53,14 @@ spec:
           {{- if .Values.bootstrap.jobs.preDelete.extraEnvs }}
           {{- include "tyk-bootstrap.tplvalues.render" ( dict "value" .Values.bootstrap.jobs.preDelete.extraEnvs "context" $ ) | nindent 12 }}
           {{- end }}
+          {{- if .Values.bootstrap.extraVolumeMounts }}
+          volumeMounts:
+            {{- include "tyk-bootstrap.tplvalues.render" (dict "value" .Values.bootstrap.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+      {{- if .Values.bootstrap.extraVolumes }}
+      volumes:
+        {{- include "tyk-bootstrap.tplvalues.render" (dict "value" .Values.bootstrap.extraVolumes "context" $) | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 0
       restartPolicy: Never
 {{- end }}

--- a/components/tyk-bootstrap/templates/bootstrap-pre-install.yaml
+++ b/components/tyk-bootstrap/templates/bootstrap-pre-install.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.components.bootstrap -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -52,5 +53,14 @@ spec:
           {{- if .Values.bootstrap.jobs.preInstall.extraEnvs }}
           {{- include "tyk-bootstrap.tplvalues.render" ( dict "value" .Values.bootstrap.jobs.preInstall.extraEnvs "context" $ ) | nindent 12 }}
           {{- end }}
+          {{- if .Values.bootstrap.extraVolumeMounts }}
+          volumeMounts:
+            {{- include "tyk-bootstrap.tplvalues.render" (dict "value" .Values.bootstrap.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+      {{- if .Values.bootstrap.extraVolumes }}
+      volumes:
+        {{- include "tyk-bootstrap.tplvalues.render" (dict "value" .Values.bootstrap.extraVolumes "context" $) | nindent 8 }}
+      {{- end }}
       restartPolicy: Never
       terminationGracePeriodSeconds: 0
+{{- end }}

--- a/components/tyk-bootstrap/values.yaml
+++ b/components/tyk-bootstrap/values.yaml
@@ -167,3 +167,18 @@ bootstrap:
     capabilities:
       drop:
         - ALL
+
+  # extraVolumes is a list of volumes to be added to the pod
+  # extraVolumes:
+  #   - name: ca-certs
+  #     secret:
+  #       defaultMode: 420
+  #       secretName: ca-certs
+  extraVolumes: []
+
+  # extraVolumeMounts is a list of volume mounts to be added to the pod
+  # extraVolumeMounts:
+  #   - name: ca-certs
+  #     mountPath: /etc/ssl/certs/ca-certs.crt
+  #     readOnly: true
+  extraVolumeMounts: []


### PR DESCRIPTION
## Description
Adds optional extraVolumes and extraVolumeMounts to bootstrap values. The volumes and volumeMounts are added to all bootstrap jobs if defined.

## Related Issue
https://github.com/TykTechnologies/tyk-charts/issues/311

## Motivation and Context
Allows using the tyk-stack chart when the Secrets Store CSI Driver is used for secrets.

## Test Coverage For This Change

a) without extraVolumes and extraVolumeMounts
<details><summary>values:</summary>
<p>

```
# Default values for tyk-bootstrap.
# This is a YAML-formatted file.
# Declare variables to be passed into your templates.

# fullnameOverride overrides App name. It is truncated to 63 characters.
fullnameOverride: ""

# nameOverride overrides the Chart name. It is truncated to 63 characters.
nameOverride: ""

global:
  license:
    # The license key needed for the Tyk Dashboard.
    dashboard: ""
  adminUser:
    # If you don't want to store plaintext secrets for admin user in the Helm value file and would
    # rather provide the k8s Secret externally please populate the value below
    # You can set following fields in the secret
    # adminUserFirstName - sets .global.adminUser.firstName
    # adminUserLastName - sets .global.adminUser.lastName
    # adminUserEmail - sets .global.adminUser.email
    useSecretName: ""

    # firstName corresponds to the first name of the admin user that will be created during the bootstrapping process.
    # It is used to set TYK_K8SBOOTSTRAP_TYK_ADMIN_FIRSTNAME
    firstName: admin
    # lastName corresponds to the last name of the admin user that will be created during the bootstrapping process.
    # It is used to set TYK_K8SBOOTSTRAP_TYK_ADMIN_LASTNAME
    lastName: user
    # email corresponds to the email of the admin user that will be created during the bootstrapping process.
    # It is used to set TYK_K8SBOOTSTRAP_TYK_ADMIN_EMAILADDRESS
    email: default@example.com

  components:
    # Determines whether the bootstrap jobs should be run
    # Those jobs verify the presence of the dashboard license and perform various operations to
    # make apps such as tyk-dashboard, tyk-portal and tyk-operator ready to use from the get go
    # If this is set to false, only the hook that checks for dashboard license will be run
    bootstrap: true

  tls:
    # If set to true the Dashboard will use SSL connection.
    dashboard: false

  secrets:
    # tyk_analytics.conf admin_secret
    AdminSecret: "12345"
    # If you don't want to store plaintext secrets in the Helm value file and would
    # rather provide the k8s Secret externally please populate the value below
    # You can set following fields in the secret
    # AdminSecret - Admin user secret key
    useSecretName: ""
    devPortal: tyk-dev-portal-conf

bootstrap:
  # Trigger to control if we want to bootstrap the Developer Portal component using tyk-bootstrap
  devPortal: true

  # Trigger to control if we want to bootstrap the dashboard component using tyk-bootstrap
  dashboard: true

  # Trigger to control if we want to bootstrap the classic portal component using tyk-bootstrap
  portal: false

  # Skip validating the SSL certificates. Usually needed when using self-signed certs.
  sslInsecureSkipVerify: false

  # Trigger to control if we want to create the tyk-operator secret
  operatorSecret: tyk-operator-conf

  # The default name for the sa is k8s-bootstrap-role
  # serviceAccountName field configures the name of the ServiceAccount that is going to be created for bootstrapping Jobs
  serviceAccountName: "k8s-bootstrap-role"

  # jobs field includes configurations for Helm Hooks.
  jobs:
    # preInstall configures pre-install Helm hook
    preInstall:
      # image specifies image repository of bootstrap images
      image:
        # repository specifies image repository of pre-install job.
        repository: tykio/tyk-k8s-bootstrap-pre-install
        # tag specifies image tag of pre-install job.
        tag: v2.1.2

      # extraEnvs is used to set extra environment variables to pre-install job.
      # - name: TYK_K8SBOOTSTRAP_TYK_DASHBOARDLICENSE
      #   value: "yourlicense"
      extraEnvs: []

    # postInstall configures post-install Helm hook
    postInstall:
      # image specifies image repository of bootstrap images
      image:
        # repository specifies image repository of post-install job.
        repository: tykio/tyk-k8s-bootstrap-post
        # tag specifies image tag of post-install job.
        tag: v2.1.2

      # extraEnvs is used to set extra environment variables to post-install job.
      # - name: TYK_K8SBOOTSTRAP_TYK_ADMIN_FIRSTNAME
      #   value: "burak"
      extraEnvs: []

    # preDelete configures pre-delete Helm hook
    preDelete:
      # image specifies image repository of bootstrap images
      image:
        # repository specifies image repository of pre-delete job.
        repository: tykio/tyk-k8s-bootstrap-pre-delete
        # tag specifies image tag of pre-delete job.
        tag: v2.1.2

      # extraEnvs is used to set extra environment variables to pre-delete job.
      # - name: TYK_K8SBOOTSTRAP_OPERATORKUBERNETESSECRETNAME
      #   value: "tyk-operator-conf"
      extraEnvs: []

  org:
    # The name for your organization inside Tyk
    name: Default Org
    # The hostname to bind the Portal to.
    cname: tyk-portal.local
    # hybrid configures whether hybrid organisation is enabled during bootstrap or not.
    hybrid:
      # Enabling hybrid allows a worker gateways to login as an organisation member into MDCB.
      # Set this field to true while using MDCB control plane.
      enabled: false

  # podAnnotations specifies annotations to be added Tyk Bootstrap job pods.
  # It takes key-value pairs.
  # There are no required annotations for Tyk Bootstrap.
  #
  # podAnnotations:
  #   postInstallPodAnnotations:
  #     key: value
  #     post: install
  #   preDeletePodAnnotations:
  #     key: value
  #     post: install
  podAnnotations:
    # preInstallPodAnnotations specifies annotations to be added to Tyk Bootstrap pre-install hook's job pods.
    preInstallPodAnnotations: {}
    # postInstallPodAnnotations specifies annotations to be added to Tyk Bootstrap post-install hook's job pods.
    postInstallPodAnnotations: {}
    # preDeletePodAnnotations specifies annotations to be added to Tyk Bootstrap pre-delete hook's job pods.
    preDeletePodAnnotations: {}

  # podLabels specifies labels to be added in bootstrap Pod
  podLabels:
    # preInstallPodLabels specifies labels to be added to Tyk Bootstrap pre-install hook's job pods.
    preInstallPodLabels: {}
    # postInstallPodLabels specifies labels to be added to Tyk Bootstrap post-install hook's job pods.
    postInstallPodLabels: {}
    # preDeletePodLabels specifies labels to be added to Tyk Bootstrap pre-delete hook's job pods.
    preDeletePodLabels: {}

  # containerSecurityContext values for bootstrap containers
  containerSecurityContext:
    runAsNonRoot: true
    runAsUser: 1000
    allowPrivilegeEscalation: false
    privileged: false
    readOnlyRootFilesystem: true
    seccompProfile:
      type: RuntimeDefault
    capabilities:
      drop:
        - ALL

  # extraVolumes is a list of volumes to be added to the pod
  # extraVolumes:
  #   - name: ca-certs
  #     secret:
  #       defaultMode: 420
  #       secretName: ca-certs
  extraVolumes: []

  # extraVolumeMounts is a list of volume mounts to be added to the pod
  # extraVolumeMounts:
  #   - name: ca-certs
  #     mountPath: /etc/ssl/certs/ca-certs.crt
  #     readOnly: true
  extraVolumeMounts: []
```

</p>
</details>


<details><summary>Templated:</summary>
<p>

```
---
# Source: tyk-bootstrap/templates/bootstrap-serviceaccount.yml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: "k8s-bootstrap-role"
  annotations:
    helm.sh/hook: pre-install
    helm.sh/hook-delete-policy: before-hook-creation
    helm.sh/hook-weight: "-10"
---
# Source: tyk-bootstrap/templates/bootstrap-role.yml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: "k8s-bootstrap-role"
  annotations:
    helm.sh/hook: pre-install
    helm.sh/hook-delete-policy: before-hook-creation
    helm.sh/hook-weight: "-10"
rules:
#
# Give here only the privileges you need
#
- apiGroups: [""]
  resources:
  - services
  - pods
  - pods/exec
  verbs:
  - get
  - list
  - create
- apiGroups: [""]
  resources:
  - secrets
  verbs:
  - get
  - list
  - create
  - delete
- apiGroups: ["batch"]
  resources:
  - jobs
  verbs:
  - delete
  - list
- apiGroups: ["apps"]
  resources: ["deployments"]
  verbs:
  - get
  - update
  - patch
  - list
---
# Source: tyk-bootstrap/templates/bootstrap-role-binding.yml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: "k8s-bootstrap-role"
  annotations:
    helm.sh/hook: pre-install
    helm.sh/hook-delete-policy: before-hook-creation
    helm.sh/hook-weight: "-10"
subjects:
- kind: ServiceAccount
  name: "k8s-bootstrap-role"
  namespace: default
roleRef:
  kind: Role
  name: k8s-bootstrap-role
  apiGroup: rbac.authorization.k8s.io
---
# Source: tyk-bootstrap/templates/bootstrap-post-install.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: bootstrap-post-install-tyk-tyk-bootstrap
  labels:
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "tyk"
    tyk.tyk.io/k8s-bootstrap: tyk-k8s-bootstrap-post-install

    # Removed the use of appVersion since it's not accurate. We'll put it back in v1.0
    # when every app will have its own a chart
    # app.kubernetes.io/version: ""
  annotations:
    # This is what defines this resource as a hook. Without this line, the
    # job is considered part of the release.
    "helm.sh/hook": post-install
    "helm.sh/hook-weight": "-5"
    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
spec:
  backoffLimit: 1
  template:
    metadata:
      annotations:
      labels:
    spec:
      serviceAccountName: "k8s-bootstrap-role"
      containers:
        - name: bootstrap-tyk-post-install
          image: tykio/tyk-k8s-bootstrap-post:v2.1.2
          command: [ '/app/bin/bootstrap-app-post' ]
          imagePullPolicy: IfNotPresent
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            privileged: false
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 1000
            seccompProfile:
              type: RuntimeDefault
          env:
            - name: TYK_K8SBOOTSTRAP_TYK_ADMIN_FIRSTNAME

              value: "admin"

            - name: TYK_K8SBOOTSTRAP_TYK_ADMIN_LASTNAME

              value: "user"

            - name: TYK_K8SBOOTSTRAP_TYK_ADMIN_EMAILADDRESS

              value: "default@example.com"

            - name: TYK_K8SBOOTSTRAP_TYK_ADMIN_PASSWORD
              valueFrom:
                secretKeyRef:
                  name:  tyk-dashboard-login-details
                  key: adminUserPassword
            - name: TYK_K8SBOOTSTRAP_K8S_RELEASENAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
            - name: TYK_K8SBOOTSTRAP_K8S_DASHBOARDSVCPROTO
              value: "http"
            - name: TYK_K8SBOOTSTRAP_INSECURESKIPVERIFY
              value: "false"
            - name: TYK_K8SBOOTSTRAP_TYK_ADMIN_SECRET
              value: "12345"
            - name: TYK_K8SBOOTSTRAP_TYK_ORG_NAME
              value: "Default Org"
            - name: TYK_K8SBOOTSTRAP_TYK_ORG_CNAME
              value: "tyk-portal.local"
            - name: TYK_K8SBOOTSTRAP_BOOTSTRAPDASHBOARD
              value: "true"
            - name: TYK_K8SBOOTSTRAP_OPERATORKUBERNETESSECRETNAME
              value: tyk-operator-conf
            - name: TYK_K8SBOOTSTRAP_BOOTSTRAPPORTAL
              value: "false"
      restartPolicy: Never
      terminationGracePeriodSeconds: 0
---
# Source: tyk-bootstrap/templates/bootstrap-pre-delete.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: "bootstrap-pre-delete-tyk-tyk-bootstrap"
  labels:
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "tyk"
    tyk.tyk.io/k8s-bootstrap: tyk-k8s-bootstrap-pre-delete

    # Removed the use of appVersion since it's not accurate. We'll put it back in v1.0
    # when every app will have its own a chart
    # app.kubernetes.io/version: ""

    helm.sh/chart: "tyk-bootstrap-1.6.0"
  annotations:
    # This is what defines this resource as a hook. Without this line, the
    # job is considered part of the release.
    "helm.sh/hook": pre-delete
    "helm.sh/hook-weight": "0"

    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
spec:
  backoffLimit: 1
  template:
    metadata:
      annotations:
      labels:
    spec:
      serviceAccountName: "k8s-bootstrap-role"
      containers:
        - name: bootstrap-tyk-pre-delete
          image: tykio/tyk-k8s-bootstrap-pre-delete:v2.1.2
          command: [ '/app/bin/bootstrap-app-pre-delete' ]
          imagePullPolicy: IfNotPresent
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            privileged: false
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 1000
            seccompProfile:
              type: RuntimeDefault
          env:
            - name: TYK_K8SBOOTSTRAP_OPERATORKUBERNETESSECRETNAME
              value: tyk-operator-conf
            - name: TYK_K8SBOOTSTRAP_K8S_RELEASENAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
      terminationGracePeriodSeconds: 0
      restartPolicy: Never
---
# Source: tyk-bootstrap/templates/bootstrap-pre-install.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: bootstrap-pre-install-tyk-tyk-bootstrap
  labels:
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "tyk"
    tyk.tyk.io/k8s-bootstrap: tyk-k8s-bootstrap-pre-install

    # Removed the use of appVersion since it's not accurate. We'll put it back in v1.0
    # when every app will have its own a chart
    # app.kubernetes.io/version: ""
  annotations:
    # This is what defines this resource as a hook. Without this line, the
    # job is considered part of the release.
    "helm.sh/hook": pre-install
    "helm.sh/hook-weight": "-5"
    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
spec:
  backoffLimit: 1
  template:
    metadata:
      annotations:
      labels:
    spec:
      serviceAccountName: "k8s-bootstrap-role"
      containers:
        - name: bootstrap-tyk-pre-install
          image: tykio/tyk-k8s-bootstrap-pre-install:v2.1.2
          command: ['/app/bin/bootstrap-app-pre-install']
          imagePullPolicy: IfNotPresent
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            privileged: false
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 1000
            seccompProfile:
              type: RuntimeDefault
          env:
            - name: TYK_K8SBOOTSTRAP_TYK_DASHBOARDLICENSE

              value: ""

          volumeMounts:
            - mountPath: /mnt/secrets-store
              name: secrets-store-mount
              readOnly: true
      volumes:
        - csi:
            driver: secrets-store.csi.k8s.io
            readOnly: true
            volumeAttributes:
              secretProviderClass: secrets-tyk
          name: secrets-store-mount
      restartPolicy: Never
      terminationGracePeriodSeconds: 0

```

</p>
</details> 
b) with extraVolumes and extraVolumeMounts

<details><summary>values:</summary>
<p>

```
# Default values for tyk-bootstrap.
# This is a YAML-formatted file.
# Declare variables to be passed into your templates.

# fullnameOverride overrides App name. It is truncated to 63 characters.
fullnameOverride: ""

# nameOverride overrides the Chart name. It is truncated to 63 characters.
nameOverride: ""

global:
  license:
    # The license key needed for the Tyk Dashboard.
    dashboard: ""
  adminUser:
    # If you don't want to store plaintext secrets for admin user in the Helm value file and would
    # rather provide the k8s Secret externally please populate the value below
    # You can set following fields in the secret
    # adminUserFirstName - sets .global.adminUser.firstName
    # adminUserLastName - sets .global.adminUser.lastName
    # adminUserEmail - sets .global.adminUser.email
    useSecretName: ""

    # firstName corresponds to the first name of the admin user that will be created during the bootstrapping process.
    # It is used to set TYK_K8SBOOTSTRAP_TYK_ADMIN_FIRSTNAME
    firstName: admin
    # lastName corresponds to the last name of the admin user that will be created during the bootstrapping process.
    # It is used to set TYK_K8SBOOTSTRAP_TYK_ADMIN_LASTNAME
    lastName: user
    # email corresponds to the email of the admin user that will be created during the bootstrapping process.
    # It is used to set TYK_K8SBOOTSTRAP_TYK_ADMIN_EMAILADDRESS
    email: default@example.com

  components:
    # Determines whether the bootstrap jobs should be run
    # Those jobs verify the presence of the dashboard license and perform various operations to
    # make apps such as tyk-dashboard, tyk-portal and tyk-operator ready to use from the get go
    # If this is set to false, only the hook that checks for dashboard license will be run
    bootstrap: true

  tls:
    # If set to true the Dashboard will use SSL connection.
    dashboard: false

  secrets:
    # tyk_analytics.conf admin_secret
    AdminSecret: "12345"
    # If you don't want to store plaintext secrets in the Helm value file and would
    # rather provide the k8s Secret externally please populate the value below
    # You can set following fields in the secret
    # AdminSecret - Admin user secret key
    useSecretName: ""
    devPortal: tyk-dev-portal-conf

bootstrap:
  # Trigger to control if we want to bootstrap the Developer Portal component using tyk-bootstrap
  devPortal: true

  # Trigger to control if we want to bootstrap the dashboard component using tyk-bootstrap
  dashboard: true

  # Trigger to control if we want to bootstrap the classic portal component using tyk-bootstrap
  portal: false

  # Skip validating the SSL certificates. Usually needed when using self-signed certs.
  sslInsecureSkipVerify: false

  # Trigger to control if we want to create the tyk-operator secret
  operatorSecret: tyk-operator-conf

  # The default name for the sa is k8s-bootstrap-role
  # serviceAccountName field configures the name of the ServiceAccount that is going to be created for bootstrapping Jobs
  serviceAccountName: "k8s-bootstrap-role"

  # jobs field includes configurations for Helm Hooks.
  jobs:
    # preInstall configures pre-install Helm hook
    preInstall:
      # image specifies image repository of bootstrap images
      image:
        # repository specifies image repository of pre-install job.
        repository: tykio/tyk-k8s-bootstrap-pre-install
        # tag specifies image tag of pre-install job.
        tag: v2.1.2

      # extraEnvs is used to set extra environment variables to pre-install job.
      # - name: TYK_K8SBOOTSTRAP_TYK_DASHBOARDLICENSE
      #   value: "yourlicense"
      extraEnvs: []

    # postInstall configures post-install Helm hook
    postInstall:
      # image specifies image repository of bootstrap images
      image:
        # repository specifies image repository of post-install job.
        repository: tykio/tyk-k8s-bootstrap-post
        # tag specifies image tag of post-install job.
        tag: v2.1.2

      # extraEnvs is used to set extra environment variables to post-install job.
      # - name: TYK_K8SBOOTSTRAP_TYK_ADMIN_FIRSTNAME
      #   value: "burak"
      extraEnvs: []

    # preDelete configures pre-delete Helm hook
    preDelete:
      # image specifies image repository of bootstrap images
      image:
        # repository specifies image repository of pre-delete job.
        repository: tykio/tyk-k8s-bootstrap-pre-delete
        # tag specifies image tag of pre-delete job.
        tag: v2.1.2

      # extraEnvs is used to set extra environment variables to pre-delete job.
      # - name: TYK_K8SBOOTSTRAP_OPERATORKUBERNETESSECRETNAME
      #   value: "tyk-operator-conf"
      extraEnvs: []

  org:
    # The name for your organization inside Tyk
    name: Default Org
    # The hostname to bind the Portal to.
    cname: tyk-portal.local
    # hybrid configures whether hybrid organisation is enabled during bootstrap or not.
    hybrid:
      # Enabling hybrid allows a worker gateways to login as an organisation member into MDCB.
      # Set this field to true while using MDCB control plane.
      enabled: false

  # podAnnotations specifies annotations to be added Tyk Bootstrap job pods.
  # It takes key-value pairs.
  # There are no required annotations for Tyk Bootstrap.
  #
  # podAnnotations:
  #   postInstallPodAnnotations:
  #     key: value
  #     post: install
  #   preDeletePodAnnotations:
  #     key: value
  #     post: install
  podAnnotations:
    # preInstallPodAnnotations specifies annotations to be added to Tyk Bootstrap pre-install hook's job pods.
    preInstallPodAnnotations: {}
    # postInstallPodAnnotations specifies annotations to be added to Tyk Bootstrap post-install hook's job pods.
    postInstallPodAnnotations: {}
    # preDeletePodAnnotations specifies annotations to be added to Tyk Bootstrap pre-delete hook's job pods.
    preDeletePodAnnotations: {}

  # podLabels specifies labels to be added in bootstrap Pod
  podLabels:
    # preInstallPodLabels specifies labels to be added to Tyk Bootstrap pre-install hook's job pods.
    preInstallPodLabels: {}
    # postInstallPodLabels specifies labels to be added to Tyk Bootstrap post-install hook's job pods.
    postInstallPodLabels: {}
    # preDeletePodLabels specifies labels to be added to Tyk Bootstrap pre-delete hook's job pods.
    preDeletePodLabels: {}

  # containerSecurityContext values for bootstrap containers
  containerSecurityContext:
    runAsNonRoot: true
    runAsUser: 1000
    allowPrivilegeEscalation: false
    privileged: false
    readOnlyRootFilesystem: true
    seccompProfile:
      type: RuntimeDefault
    capabilities:
      drop:
        - ALL

  # extraVolumes is a list of volumes to be added to the pod
  # extraVolumes:
  #   - name: ca-certs
  #     secret:
  #       defaultMode: 420
  #       secretName: ca-certs
  extraVolumes:
    - name: secrets-store-mount
      csi:
        driver: secrets-store.csi.k8s.io
        readOnly: true
        volumeAttributes:
          secretProviderClass: secrets-tyk

  # extraVolumeMounts is a list of volume mounts to be added to the pod
  # extraVolumeMounts:
  #   - name: ca-certs
  #     mountPath: /etc/ssl/certs/ca-certs.crt
  #     readOnly: true
  extraVolumeMounts:
    - name: secrets-store-mount
      mountPath: /mnt/secrets-store
      readOnly: true
```

</p>
</details>


<details><summary>Templated:</summary>
<p>

```
---
# Source: tyk-bootstrap/templates/bootstrap-serviceaccount.yml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: "k8s-bootstrap-role"
  annotations:
    helm.sh/hook: pre-install
    helm.sh/hook-delete-policy: before-hook-creation
    helm.sh/hook-weight: "-10"
---
# Source: tyk-bootstrap/templates/bootstrap-role.yml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: "k8s-bootstrap-role"
  annotations:
    helm.sh/hook: pre-install
    helm.sh/hook-delete-policy: before-hook-creation
    helm.sh/hook-weight: "-10"
rules:
#
# Give here only the privileges you need
#
- apiGroups: [""]
  resources:
  - services
  - pods
  - pods/exec
  verbs:
  - get
  - list
  - create
- apiGroups: [""]
  resources:
  - secrets
  verbs:
  - get
  - list
  - create
  - delete
- apiGroups: ["batch"]
  resources:
  - jobs
  verbs:
  - delete
  - list
- apiGroups: ["apps"]
  resources: ["deployments"]
  verbs:
  - get
  - update
  - patch
  - list
---
# Source: tyk-bootstrap/templates/bootstrap-role-binding.yml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: "k8s-bootstrap-role"
  annotations:
    helm.sh/hook: pre-install
    helm.sh/hook-delete-policy: before-hook-creation
    helm.sh/hook-weight: "-10"
subjects:
- kind: ServiceAccount
  name: "k8s-bootstrap-role"
  namespace: default
roleRef:
  kind: Role
  name: k8s-bootstrap-role
  apiGroup: rbac.authorization.k8s.io
---
# Source: tyk-bootstrap/templates/bootstrap-post-install.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: bootstrap-post-install-tyk-tyk-bootstrap
  labels:
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "tyk"
    tyk.tyk.io/k8s-bootstrap: tyk-k8s-bootstrap-post-install

    # Removed the use of appVersion since it's not accurate. We'll put it back in v1.0
    # when every app will have its own a chart
    # app.kubernetes.io/version: ""
  annotations:
    # This is what defines this resource as a hook. Without this line, the
    # job is considered part of the release.
    "helm.sh/hook": post-install
    "helm.sh/hook-weight": "-5"
    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
spec:
  backoffLimit: 1
  template:
    metadata:
      annotations:
      labels:
    spec:
      serviceAccountName: "k8s-bootstrap-role"
      containers:
        - name: bootstrap-tyk-post-install
          image: tykio/tyk-k8s-bootstrap-post:v2.1.2
          command: [ '/app/bin/bootstrap-app-post' ]
          imagePullPolicy: IfNotPresent
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            privileged: false
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 1000
            seccompProfile:
              type: RuntimeDefault
          env:
            - name: TYK_K8SBOOTSTRAP_TYK_ADMIN_FIRSTNAME

              value: "admin"

            - name: TYK_K8SBOOTSTRAP_TYK_ADMIN_LASTNAME

              value: "user"

            - name: TYK_K8SBOOTSTRAP_TYK_ADMIN_EMAILADDRESS

              value: "default@example.com"

            - name: TYK_K8SBOOTSTRAP_TYK_ADMIN_PASSWORD
              valueFrom:
                secretKeyRef:
                  name:  tyk-dashboard-login-details
                  key: adminUserPassword
            - name: TYK_K8SBOOTSTRAP_K8S_RELEASENAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
            - name: TYK_K8SBOOTSTRAP_K8S_DASHBOARDSVCPROTO
              value: "http"
            - name: TYK_K8SBOOTSTRAP_INSECURESKIPVERIFY
              value: "false"
            - name: TYK_K8SBOOTSTRAP_TYK_ADMIN_SECRET
              value: "12345"
            - name: TYK_K8SBOOTSTRAP_TYK_ORG_NAME
              value: "Default Org"
            - name: TYK_K8SBOOTSTRAP_TYK_ORG_CNAME
              value: "tyk-portal.local"
            - name: TYK_K8SBOOTSTRAP_BOOTSTRAPDASHBOARD
              value: "true"
            - name: TYK_K8SBOOTSTRAP_OPERATORKUBERNETESSECRETNAME
              value: tyk-operator-conf
            - name: TYK_K8SBOOTSTRAP_BOOTSTRAPPORTAL
              value: "false"
          volumeMounts:
            - mountPath: /mnt/secrets-store
              name: secrets-store-mount
              readOnly: true
      volumes:
        - csi:
            driver: secrets-store.csi.k8s.io
            readOnly: true
            volumeAttributes:
              secretProviderClass: secrets-tyk
          name: secrets-store-mount
      restartPolicy: Never
      terminationGracePeriodSeconds: 0
---
# Source: tyk-bootstrap/templates/bootstrap-pre-delete.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: "bootstrap-pre-delete-tyk-tyk-bootstrap"
  labels:
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "tyk"
    tyk.tyk.io/k8s-bootstrap: tyk-k8s-bootstrap-pre-delete

    # Removed the use of appVersion since it's not accurate. We'll put it back in v1.0
    # when every app will have its own a chart
    # app.kubernetes.io/version: ""

    helm.sh/chart: "tyk-bootstrap-1.6.0"
  annotations:
    # This is what defines this resource as a hook. Without this line, the
    # job is considered part of the release.
    "helm.sh/hook": pre-delete
    "helm.sh/hook-weight": "0"

    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
spec:
  backoffLimit: 1
  template:
    metadata:
      annotations:
      labels:
    spec:
      serviceAccountName: "k8s-bootstrap-role"
      containers:
        - name: bootstrap-tyk-pre-delete
          image: tykio/tyk-k8s-bootstrap-pre-delete:v2.1.2
          command: [ '/app/bin/bootstrap-app-pre-delete' ]
          imagePullPolicy: IfNotPresent
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            privileged: false
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 1000
            seccompProfile:
              type: RuntimeDefault
          env:
            - name: TYK_K8SBOOTSTRAP_OPERATORKUBERNETESSECRETNAME
              value: tyk-operator-conf
            - name: TYK_K8SBOOTSTRAP_K8S_RELEASENAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
          volumeMounts:
            - mountPath: /mnt/secrets-store
              name: secrets-store-mount
              readOnly: true
      volumes:
        - csi:
            driver: secrets-store.csi.k8s.io
            readOnly: true
            volumeAttributes:
              secretProviderClass: secrets-tyk
          name: secrets-store-mount
      terminationGracePeriodSeconds: 0
      restartPolicy: Never
---
# Source: tyk-bootstrap/templates/bootstrap-pre-install.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: bootstrap-pre-install-tyk-tyk-bootstrap
  labels:
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "tyk"
    tyk.tyk.io/k8s-bootstrap: tyk-k8s-bootstrap-pre-install

    # Removed the use of appVersion since it's not accurate. We'll put it back in v1.0
    # when every app will have its own a chart
    # app.kubernetes.io/version: ""
  annotations:
    # This is what defines this resource as a hook. Without this line, the
    # job is considered part of the release.
    "helm.sh/hook": pre-install
    "helm.sh/hook-weight": "-5"
    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
spec:
  backoffLimit: 1
  template:
    metadata:
      annotations:
      labels:
    spec:
      serviceAccountName: "k8s-bootstrap-role"
      containers:
        - name: bootstrap-tyk-pre-install
          image: tykio/tyk-k8s-bootstrap-pre-install:v2.1.2
          command: ['/app/bin/bootstrap-app-pre-install']
          imagePullPolicy: IfNotPresent
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            privileged: false
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 1000
            seccompProfile:
              type: RuntimeDefault
          env:
            - name: TYK_K8SBOOTSTRAP_TYK_DASHBOARDLICENSE

              value: ""

          volumeMounts:
            - mountPath: /mnt/secrets-store
              name: secrets-store-mount
              readOnly: true
      volumes:
        - csi:
            driver: secrets-store.csi.k8s.io
            readOnly: true
            volumeAttributes:
              secretProviderClass: secrets-tyk
          name: secrets-store-mount
      restartPolicy: Never
      terminationGracePeriodSeconds: 0

```

</p>
</details> 

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] Documentation updates or improvements.


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
     - [ ] I have manually updated the README(s)/documentation accordingly.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.