### PR TITLE
[TT-13080], added support for path prefix/suffix matching env vars

### DIFF
--- a/components/tyk-gateway/templates/deployment-gw-repset.yaml
+++ b/components/tyk-gateway/templates/deployment-gw-repset.yaml
@@ -127,6 +127,8 @@ spec:
             value: "{{ .Values.gateway.enablePathPrefixMatching }}"
           - name: TYK_GW_HTTPSERVEROPTIONS_ENABLEPATHSUFFIXMATCHING
             value: "{{ .Values.gateway.enablePathSuffixMatching }}"
+          - name: TYK_GW_HTTPSERVEROPTIONS_ENABLESTRICTROUTES
+            value: "{{ .Values.gateway.enableStrictRoutes }}"
 
           {{- if .Values.global.redis.sslInsecureSkipVerify }}
           - name: TYK_GW_STORAGE_SSLINSECURESKIPVERIFY

--- a/components/tyk-gateway/templates/deployment-gw-repset.yaml
+++ b/components/tyk-gateway/templates/deployment-gw-repset.yaml
@@ -123,6 +123,10 @@ spec:
             value: "{{ .Values.global.oasValidateSchemaDefaults }}"
           - name: TYK_GW_ENABLEFIXEDWINDOWRATELIMITER
             value: "{{ .Values.gateway.enableFixedWindowRateLimiter }}"
+          - name: TYK_GW_HTTPSERVEROPTIONS_ENABLEPATHPREFIXMATCHING
+            value: "{{ .Values.gateway.enablePathPrefixMatching }}"
+          - name: TYK_GW_HTTPSERVEROPTIONS_ENABLEPATHSUFFIXMATCHING
+            value: "{{ .Values.gateway.enablePathSuffixMatching }}"
 
           {{- if .Values.global.redis.sslInsecureSkipVerify }}
           - name: TYK_GW_STORAGE_SSLINSECURESKIPVERIFY

--- a/components/tyk-gateway/values.yaml
+++ b/components/tyk-gateway/values.yaml
@@ -501,6 +501,11 @@ gateway:
   # - the stripped listen path URL (/v4/json)
   # - the stripped version information (/json)
   enablePathSuffixMatching: true
+  # EnableStrictRoutes changes the routing to avoid nearest-neighbour requests on overlapping routes
+  # - if disabled, `/apple` will route to `/app`, the current default behavior,
+  # - if enabled, `/app` only responds to `/app`, `/app/` and `/app/*` but not `/apple`
+  # Regular expressions and parameterized routes will be left alone regardless of this setting.
+  enableStrictRoutes: true
 
 
   # serviceAccountName field indicates the name of the Service Account that is going to be used by the Pods.

--- a/components/tyk-gateway/values.yaml
+++ b/components/tyk-gateway/values.yaml
@@ -489,6 +489,20 @@ gateway:
       # all the subsequent work that operation causes
       parentBased: false
 
+  # EnablePathPrefixMatching changes the URL matching from wildcard mode to prefix mode.
+  # If prefix matching is enabled, the match will be performed
+  # - as a prefix match (/json*).
+  # - against the full listen path and versioning URL (/listen-path/v4/json)
+  # - the stripped listen path URL (/v4/json), and the stripped version information (/json).
+  enablePathPrefixMatching: true
+  # EnablePathSuffixMatching changes the URL matching to match as a suffix.
+  # For example, /json is matched as /json$ against
+  # - the full listen path and versioning URL (/listen-path/v4/json)
+  # - the stripped listen path URL (/v4/json)
+  # - the stripped version information (/json)
+  enablePathSuffixMatching: true
+
+
   # serviceAccountName field indicates the name of the Service Account that is going to be used by the Pods.
   # If a service account is to be used for Tyk Gateway, it should be manually created
   serviceAccountName: ""

--- a/tyk-control-plane/values.yaml
+++ b/tyk-control-plane/values.yaml
@@ -505,6 +505,19 @@ tyk-gateway:
         # all the subsequent work that operation causes
         parentBased: false
 
+    # EnablePathPrefixMatching changes the URL matching from wildcard mode to prefix mode.
+    # If prefix matching is enabled, the match will be performed
+    # - as a prefix match (/json*).
+    # - against the full listen path and versioning URL (/listen-path/v4/json)
+    # - the stripped listen path URL (/v4/json), and the stripped version information (/json).
+    enablePathPrefixMatching: true
+    # EnablePathSuffixMatching changes the URL matching to match as a suffix.
+    # For example, /json is matched as /json$ against
+    # - the full listen path and versioning URL (/listen-path/v4/json)
+    # - the stripped listen path URL (/v4/json)
+    # - the stripped version information (/json)
+    enablePathSuffixMatching: true
+
     # extraEnvs is used to set gateway env variables
     # - name: TYK_GW_HTTPSERVEROPTIONS_SSLINSECURESKIPVERIFY
     #   value: "true"

--- a/tyk-control-plane/values.yaml
+++ b/tyk-control-plane/values.yaml
@@ -517,6 +517,11 @@ tyk-gateway:
     # - the stripped listen path URL (/v4/json)
     # - the stripped version information (/json)
     enablePathSuffixMatching: true
+    # EnableStrictRoutes changes the routing to avoid nearest-neighbour requests on overlapping routes
+    # - if disabled, `/apple` will route to `/app`, the current default behavior,
+    # - if enabled, `/app` only responds to `/app`, `/app/` and `/app/*` but not `/apple`
+    # Regular expressions and parameterized routes will be left alone regardless of this setting.
+    enableStrictRoutes: true
 
     # extraEnvs is used to set gateway env variables
     # - name: TYK_GW_HTTPSERVEROPTIONS_SSLINSECURESKIPVERIFY

--- a/tyk-data-plane/values.yaml
+++ b/tyk-data-plane/values.yaml
@@ -467,6 +467,19 @@ tyk-gateway:
         # all the subsequent work that operation causes
         parentBased: false
 
+    # EnablePathPrefixMatching changes the URL matching from wildcard mode to prefix mode.
+    # If prefix matching is enabled, the match will be performed
+    # - as a prefix match (/json*).
+    # - against the full listen path and versioning URL (/listen-path/v4/json)
+    # - the stripped listen path URL (/v4/json), and the stripped version information (/json).
+    enablePathPrefixMatching: true
+    # EnablePathSuffixMatching changes the URL matching to match as a suffix.
+    # For example, /json is matched as /json$ against
+    # - the full listen path and versioning URL (/listen-path/v4/json)
+    # - the stripped listen path URL (/v4/json)
+    # - the stripped version information (/json)
+    enablePathSuffixMatching: true
+
     # extraVolumes is a list of volumes to be added to the pod
     # extraVolumes:
     #   - name: ca-certs

--- a/tyk-data-plane/values.yaml
+++ b/tyk-data-plane/values.yaml
@@ -479,6 +479,11 @@ tyk-gateway:
     # - the stripped listen path URL (/v4/json)
     # - the stripped version information (/json)
     enablePathSuffixMatching: true
+    # EnableStrictRoutes changes the routing to avoid nearest-neighbour requests on overlapping routes
+    # - if disabled, `/apple` will route to `/app`, the current default behavior,
+    # - if enabled, `/app` only responds to `/app`, `/app/` and `/app/*` but not `/apple`
+    # Regular expressions and parameterized routes will be left alone regardless of this setting.
+    enableStrictRoutes: true
 
     # extraVolumes is a list of volumes to be added to the pod
     # extraVolumes:

--- a/tyk-oss/values.yaml
+++ b/tyk-oss/values.yaml
@@ -426,6 +426,19 @@ tyk-gateway:
         # all the subsequent work that operation causes
         parentBased: false
 
+    # EnablePathPrefixMatching changes the URL matching from wildcard mode to prefix mode.
+    # If prefix matching is enabled, the match will be performed
+    # - as a prefix match (/json*).
+    # - against the full listen path and versioning URL (/listen-path/v4/json)
+    # - the stripped listen path URL (/v4/json), and the stripped version information (/json).
+    enablePathPrefixMatching: true
+    # EnablePathSuffixMatching changes the URL matching to match as a suffix.
+    # For example, /json is matched as /json$ against
+    # - the full listen path and versioning URL (/listen-path/v4/json)
+    # - the stripped listen path URL (/v4/json)
+    # - the stripped version information (/json)
+    enablePathSuffixMatching: true
+
     # extraEnvs is used to set gateway env variables
     # - name: TYK_GW_HTTPSERVEROPTIONS_SSLINSECURESKIPVERIFY
     #   value: "true"

--- a/tyk-oss/values.yaml
+++ b/tyk-oss/values.yaml
@@ -438,6 +438,11 @@ tyk-gateway:
     # - the stripped listen path URL (/v4/json)
     # - the stripped version information (/json)
     enablePathSuffixMatching: true
+    # EnableStrictRoutes changes the routing to avoid nearest-neighbour requests on overlapping routes
+    # - if disabled, `/apple` will route to `/app`, the current default behavior,
+    # - if enabled, `/app` only responds to `/app`, `/app/` and `/app/*` but not `/apple`
+    # Regular expressions and parameterized routes will be left alone regardless of this setting.
+    enableStrictRoutes: true
 
     # extraEnvs is used to set gateway env variables
     # - name: TYK_GW_HTTPSERVEROPTIONS_SSLINSECURESKIPVERIFY

--- a/tyk-stack/values.yaml
+++ b/tyk-stack/values.yaml
@@ -511,6 +511,19 @@ tyk-gateway:
         # all the subsequent work that operation causes
         parentBased: false
 
+    # EnablePathPrefixMatching changes the URL matching from wildcard mode to prefix mode.
+    # If prefix matching is enabled, the match will be performed
+    # - as a prefix match (/json*).
+    # - against the full listen path and versioning URL (/listen-path/v4/json)
+    # - the stripped listen path URL (/v4/json), and the stripped version information (/json).
+    enablePathPrefixMatching: true
+    # EnablePathSuffixMatching changes the URL matching to match as a suffix.
+    # For example, /json is matched as /json$ against
+    # - the full listen path and versioning URL (/listen-path/v4/json)
+    # - the stripped listen path URL (/v4/json)
+    # - the stripped version information (/json)
+    enablePathSuffixMatching: true
+
     # extraEnvs is used to set gateway env variables
     # - name: TYK_GW_HTTPSERVEROPTIONS_SSLINSECURESKIPVERIFY
     #   value: "true"

--- a/tyk-stack/values.yaml
+++ b/tyk-stack/values.yaml
@@ -523,6 +523,11 @@ tyk-gateway:
     # - the stripped listen path URL (/v4/json)
     # - the stripped version information (/json)
     enablePathSuffixMatching: true
+    # EnableStrictRoutes changes the routing to avoid nearest-neighbour requests on overlapping routes
+    # - if disabled, `/apple` will route to `/app`, the current default behavior,
+    # - if enabled, `/app` only responds to `/app`, `/app/` and `/app/*` but not `/apple`
+    # Regular expressions and parameterized routes will be left alone regardless of this setting.
+    enableStrictRoutes: true
 
     # extraEnvs is used to set gateway env variables
     # - name: TYK_GW_HTTPSERVEROPTIONS_SSLINSECURESKIPVERIFY


### PR DESCRIPTION
## Description

Added support for TYK_GW_HTTPSERVEROPTIONS_ENABLEPATHPREFIXMATCHING and TYK_GW_HTTPSERVEROPTIONS_ENABLEPATHSUFFIXMATCHING introduced in the latest Tyk release. The new variables are set to true by default to promote unambiguous route matching.

TASK: https://tyktech.atlassian.net/browse/TT-13080
PARENT TASK: https://tyktech.atlassian.net/browse/TT-12865
## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## Test Coverage For This Change
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] Documentation updates or improvements.


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [ ] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
     - [ ] I have manually updated the README(s)/documentation accordingly.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.