### PR TITLE
Fixed template name of opentelemetry caFilePath

### DIFF
--- a/components/tyk-gateway/templates/deployment-gw-repset.yaml
+++ b/components/tyk-gateway/templates/deployment-gw-repset.yaml
@@ -360,7 +360,7 @@ spec:
 
           {{- if .Values.gateway.opentelemetry.tls.caFileName }}
           - name: TYK_GW_OPENTELEMETRY_TLS_CAFILE
-            value:  {{ include "otel-CAPath" . | quote }}
+            value:  {{ include "otel-tlsCAPath" . | quote }}
           {{- end }}
 
           - name: TYK_GW_OPENTELEMETRY_TLS_MAXVERSION


### PR DESCRIPTION
## Description
Changes the named template included in the tyk-gateway deployment yaml to the name defined in _helpers.tpl.

## Related Issue
https://github.com/TykTechnologies/tyk-charts/issues/343
Closes #343 

## Motivation and Context
When setting a custom CA file for opentelemetry with the tyk-gateway helm chart this value was lost.

## Test Coverage For This Change
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] Documentation updates or improvements.


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
     - [ ] I have manually updated the README(s)/documentation accordingly.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.