### PR TITLE
Adds customization for liveness and readiness probes

### DIFF
--- a/components/tyk-gateway/templates/deployment-gw-repset.yaml
+++ b/components/tyk-gateway/templates/deployment-gw-repset.yaml
@@ -421,6 +421,9 @@ spec:
           {{- include "tyk-gateway.tplvalues.render" (dict "value" .Values.gateway.extraVolumeMounts "context" $) | nindent 10 }}
           {{- end }}
         livenessProbe:
+          {{- if .Values.gateway.livenessProbe }}
+          {{- toYaml .Values.gateway.livenessProbe | nindent 10}}
+          {{- else }}
           httpGet:
             scheme: "HTTP{{ if .Values.global.tls.gateway }}S{{ end }}"
             path: /hello
@@ -433,7 +436,11 @@ spec:
           periodSeconds: 2
           timeoutSeconds: 3
           failureThreshold: 2
+          {{- end }}
         readinessProbe:
+          {{- if .Values.gateway.readinessProbe }}
+          {{- toYaml .Values.gateway.readinessProbe | nindent 10}}
+          {{- else }}
           httpGet:
             scheme: "HTTP{{ if .Values.global.tls.gateway }}S{{ end }}"
             path: /hello
@@ -446,6 +453,7 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 3
           failureThreshold: 3
+          {{- end }}
       {{- with .Values.gateway.extraContainers }}
       {{- include "tyk-gateway.tplvalues.render" (dict "value" . "context" $) | nindent 6 }}
       {{- end }}

--- a/components/tyk-gateway/values.yaml
+++ b/components/tyk-gateway/values.yaml
@@ -389,6 +389,33 @@ gateway:
   #  memory: 128Mi
   resources: {}
 
+  # livenessProbe values for gateway pod. All fields from PodLivenessProbe object can be added here.
+  # If set to empty or nil, the default health check on /health will be performed.
+  # livenessProbe:
+  #   httpGet:
+  #     scheme: http
+  #     path: /hello
+  #     port: 8080
+  #   initialDelaySeconds: 5
+  #   periodSeconds: 2
+  #   timeoutSeconds: 3
+  #   failureThreshold: 2
+  #   successThreshold: 2
+  livenessProbe: {}
+
+  # readinessProbe values for gateway pod. All fields from PodReadinessProbe object can be added here.
+  # If set to empty or nil, the default health check on /health will be performed.
+  # readinessProbe:
+  #   httpGet:
+  #     scheme: http
+  #     path: /hello
+  #     port: 8080
+  #  initialDelaySeconds: 1
+  #  periodSeconds: 10
+  #  timeoutSeconds: 3
+  #  failureThreshold: 3
+  readinessProbe: {}
+
   # securityContext values for gateway pod. All fields from PodSecurityContext object can be added here.
   securityContext:
     runAsUser: 1000

--- a/tyk-control-plane/values.yaml
+++ b/tyk-control-plane/values.yaml
@@ -429,6 +429,33 @@ tyk-gateway:
     #  memory: 128Mi
     resources: {}
 
+    # livenessProbe values for gateway pod. All fields from PodLivenessProbe object can be added here.
+    # If set to empty or nil, the default health check on /health will be performed.
+    # livenessProbe:
+    #   httpGet:
+    #     scheme: http
+    #     path: /hello
+    #     port: 8080
+    #   initialDelaySeconds: 5
+    #   periodSeconds: 2
+    #   timeoutSeconds: 3
+    #   failureThreshold: 2
+    #   successThreshold: 2
+    livenessProbe: {}
+
+    # readinessProbe values for gateway pod. All fields from PodReadinessProbe object can be added here.
+    # If set to empty or nil, the default health check on /health will be performed.
+    # readinessProbe:
+    #   httpGet:
+    #     scheme: http
+    #     path: /hello
+    #     port: 8080
+    #  initialDelaySeconds: 1
+    #  periodSeconds: 10
+    #  timeoutSeconds: 3
+    #  failureThreshold: 3
+    readinessProbe: {}
+
     # securityContext values for gateway pod. All fields from PodSecurityContext object can be added here.
     securityContext:
       runAsUser: 1000

--- a/tyk-data-plane/values.yaml
+++ b/tyk-data-plane/values.yaml
@@ -372,6 +372,33 @@ tyk-gateway:
     #  memory: 128Mi
     resources: {}
 
+    # livenessProbe values for gateway pod. All fields from PodLivenessProbe object can be added here.
+    # If set to empty or nil, the default health check on /health will be performed.
+    # livenessProbe:
+    #   httpGet:
+    #     scheme: http
+    #     path: /hello
+    #     port: 8080
+    #   initialDelaySeconds: 5
+    #   periodSeconds: 2
+    #   timeoutSeconds: 3
+    #   failureThreshold: 2
+    #   successThreshold: 2
+    livenessProbe: {}
+
+    # readinessProbe values for gateway pod. All fields from PodReadinessProbe object can be added here.
+    # If set to empty or nil, the default health check on /health will be performed.
+    # readinessProbe:
+    #   httpGet:
+    #     scheme: http
+    #     path: /hello
+    #     port: 8080
+    #  initialDelaySeconds: 1
+    #  periodSeconds: 10
+    #  timeoutSeconds: 3
+    #  failureThreshold: 3
+    readinessProbe: {}
+
     # securityContext values for gateway pod. All fields from PodSecurityContext object can be added here.
     securityContext:
       runAsUser: 1000

--- a/tyk-oss/values.yaml
+++ b/tyk-oss/values.yaml
@@ -354,6 +354,33 @@ tyk-gateway:
     #  memory: 128Mi
     resources: {}
 
+    # livenessProbe values for gateway pod. All fields from PodLivenessProbe object can be added here.
+    # If set to empty or nil, the default health check on /health will be performed.
+    # livenessProbe:
+    #   httpGet:
+    #     scheme: http
+    #     path: /hello
+    #     port: 8080
+    #   initialDelaySeconds: 5
+    #   periodSeconds: 2
+    #   timeoutSeconds: 3
+    #   failureThreshold: 2
+    #   successThreshold: 2
+    livenessProbe: {}
+
+    # readinessProbe values for gateway pod. All fields from PodReadinessProbe object can be added here.
+    # If set to empty or nil, the default health check on /health will be performed.
+    # readinessProbe:
+    #   httpGet:
+    #     scheme: http
+    #     path: /hello
+    #     port: 8080
+    #  initialDelaySeconds: 1
+    #  periodSeconds: 10
+    #  timeoutSeconds: 3
+    #  failureThreshold: 3
+    readinessProbe: {}
+
     # securityContext values for gateway pod. All fields from PodSecurityContext object can be added here.
     securityContext:
       runAsUser: 1000

--- a/tyk-stack/values.yaml
+++ b/tyk-stack/values.yaml
@@ -445,6 +445,33 @@ tyk-gateway:
     #  memory: 128Mi
     resources: {}
 
+    # livenessProbe values for gateway pod. All fields from PodLivenessProbe object can be added here.
+    # If set to empty or nil, the default health check on /health will be performed.
+    # livenessProbe:
+    #   httpGet:
+    #     scheme: http
+    #     path: /hello
+    #     port: 8080
+    #   initialDelaySeconds: 5
+    #   periodSeconds: 2
+    #   timeoutSeconds: 3
+    #   failureThreshold: 2
+    #   successThreshold: 2
+    livenessProbe: {}
+
+    # readinessProbe values for gateway pod. All fields from PodReadinessProbe object can be added here.
+    # If set to empty or nil, the default health check on /health will be performed.
+    # readinessProbe:
+    #   httpGet:
+    #     scheme: http
+    #     path: /hello
+    #     port: 8080
+    #  initialDelaySeconds: 1
+    #  periodSeconds: 10
+    #  timeoutSeconds: 3
+    #  failureThreshold: 3
+    readinessProbe: {}
+
     # securityContext values for gateway pod. All fields from PodSecurityContext object can be added here.
     securityContext:
       runAsUser: 1000


### PR DESCRIPTION
## Description
Allows for customization of `livenessProbe` and `readinessProbe`

## Related Issue
https://github.com/TykTechnologies/tyk/issues/6674

## Motivation and Context
This allows teams to specify custom liveness and readiness probes. 
In our team we want for a pod to be considered unhealthy if the response of the `/health` endpoint is not `pass`. In order to do that, we need to be able to customise the various probes.

## Test Coverage For This Change
Tested trough usage of `helm template`

## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] Documentation updates or improvements.


## Checklist
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
     - [ ] I have manually updated the README(s)/documentation accordingly.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.