### PR TITLE
TT-13680 - feat: add option to get one OpenTelemetry header from a K8s secret

### DIFF
--- a/components/tyk-gateway/templates/deployment-gw-repset.yaml
+++ b/components/tyk-gateway/templates/deployment-gw-repset.yaml
@@ -338,9 +338,18 @@ spec:
             value: "{{ .Values.gateway.opentelemetry.exporter }}"
           - name: TYK_GW_OPENTELEMETRY_ENDPOINT
             value: "{{ .Values.gateway.opentelemetry.endpoint}}"
+            {{- if and .Values.gateway.opentelemetry.headers .Values.gateway.opentelemetry.headerSecret.name }}
+              {{- fail "You can't use '.Values.gateway.opentelemetry.headers' and '.Values.gateway.opentelemetry.headerSecret' at the same time!" }}
+            {{- end }}
             {{- if .Values.gateway.opentelemetry.headers }}
           - name: TYK_GW_OPENTELEMETRY_HEADERS
             value: "{{ include "otel-headers" . }}"
+            {{- else if and .Values.gateway.opentelemetry.headerSecret.name .Values.gateway.opentelemetry.headerSecret.key }}
+          - name: TYK_GW_OPENTELEMETRY_HEADERS
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.gateway.opentelemetry.headerSecret.name | quote }}
+                key: {{ .Values.gateway.opentelemetry.headerSecret.key | quote }}
             {{- end }}
           - name: TYK_GW_OPENTELEMETRY_CONNECTIONTIMEOUT
             value: "{{ .Values.gateway.opentelemetry.connectionTimeout }}"

--- a/components/tyk-gateway/values.yaml
+++ b/components/tyk-gateway/values.yaml
@@ -514,6 +514,22 @@ gateway:
     # A map of headers that will be sent with HTTP requests to the collector.
     # It should be set to map of string to string
     headers: {}
+    # A secret that supplies *one* header which is sent with HTTP requests to the collector. Useful for Authorization
+    # headers, which should not be exposed in the Helm values file.
+    # The key of the secret will be used as the header name, and the value will be used as the header value.
+    # Example:
+    #
+    # headerSecret:
+    #   name: otel-auth-secret
+    #   key: Authorization
+    #
+    # This example will be converted to the following header:
+    # Authorization: <value of the secret>
+    #
+    # Note that the headerSecret setting can't be used at the same time as the headers setting.
+    headerSecret:
+      name: otel-auth-secret
+      key: Authorization
     # Timeout for establishing a connection to the collector
     connectionTimeout: 1
     # Name of the resource that will be used to identify the resource.

--- a/tyk-control-plane/values.yaml
+++ b/tyk-control-plane/values.yaml
@@ -510,6 +510,22 @@ tyk-gateway:
       # A map of headers that will be sent with HTTP requests to the collector.
       # It should be set to map of string to string
       headers: {}
+      # A secret that supplies *one* header which is sent with HTTP requests to the collector. Useful for Authorization
+      # headers, which should not be exposed in the Helm values file.
+      # The key of the secret will be used as the header name, and the value will be used as the header value.
+      # Example:
+      #
+      # headerSecret:
+      #   name: otel-auth-secret
+      #   key: Authorization
+      #
+      # This example will be converted to the following header:
+      # Authorization: <value of the secret>
+      #
+      # Note that the headerSecret setting can't be used at the same time as the headers setting.
+      headerSecret:
+        name: otel-auth-secret
+        key: Authorization
       # Timeout for establishing a connection to the collector
       connectionTimeout: 1
       # Name of the resource that will be used to identify the resource.

--- a/tyk-data-plane/values.yaml
+++ b/tyk-data-plane/values.yaml
@@ -488,6 +488,22 @@ tyk-gateway:
       # A map of headers that will be sent with HTTP requests to the collector.
       # It should be set to map of string to string
       headers: {}
+      # A secret that supplies *one* header which is sent with HTTP requests to the collector. Useful for Authorization
+      # headers, which should not be exposed in the Helm values file.
+      # The key of the secret will be used as the header name, and the value will be used as the header value.
+      # Example:
+      #
+      # headerSecret:
+      #   name: otel-auth-secret
+      #   key: Authorization
+      #
+      # This example will be converted to the following header:
+      # Authorization: <value of the secret>
+      #
+      # Note that the headerSecret setting can't be used at the same time as the headers setting.
+      headerSecret:
+        name: otel-auth-secret
+        key: Authorization
       # Timeout for establishing a connection to the collector
       connectionTimeout: 1
       # Name of the resource that will be used to identify the resource.

--- a/tyk-oss/values.yaml
+++ b/tyk-oss/values.yaml
@@ -444,6 +444,22 @@ tyk-gateway:
       # A map of headers that will be sent with HTTP requests to the collector.
       # It should be set to map of string to string
       headers: {}
+      # A secret that supplies *one* header which is sent with HTTP requests to the collector. Useful for Authorization
+      # headers, which should not be exposed in the Helm values file.
+      # The key of the secret will be used as the header name, and the value will be used as the header value.
+      # Example:
+      #
+      # headerSecret:
+      #   name: otel-auth-secret
+      #   key: Authorization
+      #
+      # This example will be converted to the following header:
+      # Authorization: <value of the secret>
+      #
+      # Note that the headerSecret setting can't be used at the same time as the headers setting.
+      headerSecret:
+        name: otel-auth-secret
+        key: Authorization
       # Timeout for establishing a connection to the collector
       connectionTimeout: 1
       # Name of the resource that will be used to identify the resource.

--- a/tyk-stack/values.yaml
+++ b/tyk-stack/values.yaml
@@ -537,6 +537,22 @@ tyk-gateway:
       # A map of headers that will be sent with HTTP requests to the collector.
       # It should be set to map of string to string
       headers: {}
+      # A secret that supplies *one* header which is sent with HTTP requests to the collector. Useful for Authorization
+      # headers, which should not be exposed in the Helm values file.
+      # The key of the secret will be used as the header name, and the value will be used as the header value.
+      # Example:
+      #
+      # headerSecret:
+      #   name: otel-auth-secret
+      #   key: Authorization
+      #
+      # This example will be converted to the following header:
+      # Authorization: <value of the secret>
+      #
+      # Note that the headerSecret setting can't be used at the same time as the headers setting.
+      headerSecret:
+        name: otel-auth-secret
+        key: Authorization
       # Timeout for establishing a connection to the collector
       connectionTimeout: 1
       # Name of the resource that will be used to identify the resource.


### PR DESCRIPTION
## Description
This change allows you to add one Authorization header to the OpenTelemetry traffic in a secure way. A Bearer token is typically secret and should not be exposed in the Helm values file or in the K8s manifest of the Tyk Gateway deployment.

I'm sure this is not the most optimal way to implement this; for example, with my solution you can only use either the `headers` or `headerSecret` value, but not both at the same time. This would limit you to exactly one header, if you're using the `headerSecret`. I just want to start a discussion about a good way to solve the linked issue.

## Related Issue
https://github.com/TykTechnologies/tyk-charts/issues/363

https://tyktech.atlassian.net/browse/TT-13680

## Motivation and Context
This change improves the protection of sensitive authorization secrets.

## Test Coverage For This Change
I have templated the charts locally and inspected the result manually.

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] Documentation updates or improvements.


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [x] My change requires a change to the documentation.
     - [x] I have manually updated the README(s)/documentation accordingly.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.