### PR TITLE
Make "livenessProbe" and "readinessProbe" Configurable

### DIFF
--- a/components/tyk-gateway/templates/deployment-gw-repset.yaml
+++ b/components/tyk-gateway/templates/deployment-gw-repset.yaml
@@ -441,10 +441,10 @@ spec:
             {{- else }}
             port: {{ .Values.gateway.containerPort }}
             {{- end }}
-          initialDelaySeconds: 5
-          periodSeconds: 2
-          timeoutSeconds: 3
-          failureThreshold: 2
+          initialDelaySeconds: {{ .Values.gateway.livenessProbe.initialDelaySeconds | default 10 }}
+          periodSeconds: {{ .Values.gateway.livenessProbe.periodSeconds | default 2 }}
+          timeoutSeconds: {{ .Values.gateway.livenessProbe.timeoutSeconds | default 3 }}
+          failureThreshold: {{ .Values.gateway.livenessProbe.failureThreshold | default 2 }}
           {{- end }}
         readinessProbe:
           {{- if .Values.gateway.readinessProbe }}
@@ -458,10 +458,10 @@ spec:
             {{- else }}
             port: {{ .Values.gateway.containerPort }}
             {{- end }}
-          initialDelaySeconds: 1
-          periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 3
+          initialDelaySeconds: {{ .Values.gateway.readinessProbe.initialDelaySeconds | default 10 }}
+          periodSeconds: {{ .Values.gateway.readinessProbe.periodSeconds | default 10 }}
+          timeoutSeconds: {{ .Values.gateway.readinessProbe.timeoutSeconds | default 3 }}
+          failureThreshold: {{ .Values.gateway.readinessProbe.failureThreshold | default 3 }}
           {{- end }}
       {{- with .Values.gateway.extraContainers }}
       {{- include "tyk-gateway.tplvalues.render" (dict "value" . "context" $) | nindent 6 }}


### PR DESCRIPTION
This PR makes the `livenessProbe" and "readinessProbe" configurable  in the Tyk Gateway deployment.

Changes made:
- Added support for overriding  for both liveness and readiness probes through `values.yaml`.

This change provides more flexibility for configuring the probes based on different environments.

Fixes #<issue-number> (if applicable)

