### PR TITLE
[tyk-dashboard] Allow not setting certain postgres connection env vars

### DIFF
--- a/components/tyk-dashboard/templates/deployment-dashboard.yaml
+++ b/components/tyk-dashboard/templates/deployment-dashboard.yaml
@@ -240,29 +240,41 @@ spec:
           {{ end }}
 
           {{ if eq "postgres" (include "tyk-dashboard.storageType" .) }}
+          {{- if not (has "TYK_DB_STORAGE_MAIN_TYPE" .Values.global.postgres.unsetConnectionEnvVars | default dict) }}
           - name: TYK_DB_STORAGE_MAIN_TYPE
             value: "postgres"
+          {{- end }}
+          {{- if not (has "TYK_DB_STORAGE_MAIN_CONNECTIONSTRING" .Values.global.postgres.unsetConnectionEnvVars | default dict) }}
           - name: TYK_DB_STORAGE_MAIN_CONNECTIONSTRING
             valueFrom:
               secretKeyRef:
                 name: {{ include "tyk-dashboard.pg_connection_string_secret_name" . }}
                 key: {{ include "tyk-dashboard.pg_connection_string_secret_key" . }}
+          {{- end }}
 
+          {{- if not (has "TYK_DB_STORAGE_ANALYTICS_TYPE" .Values.global.postgres.unsetConnectionEnvVars | default dict) }}
           - name: TYK_DB_STORAGE_ANALYTICS_TYPE
             value: "postgres"
+          {{- end }}
+          {{- if not (has "TYK_DB_STORAGE_ANALYTICS_CONNECTIONSTRING" .Values.global.postgres.unsetConnectionEnvVars | default dict) }}
           - name: TYK_DB_STORAGE_ANALYTICS_CONNECTIONSTRING
             valueFrom:
              secretKeyRef:
                 name: {{ include "tyk-dashboard.pg_connection_string_secret_name" . }}
                 key: {{ include "tyk-dashboard.pg_connection_string_secret_key" . }}
+          {{- end }}
 
+          {{- if not (has "TYK_DB_STORAGE_UPTIME_TYPE" .Values.global.postgres.unsetConnectionEnvVars | default dict) }}
           - name: TYK_DB_STORAGE_UPTIME_TYPE
             value: "postgres"
+          {{- end }}
+          {{- if not (has "TYK_DB_STORAGE_UPTIME_CONNECTIONSTRING" .Values.global.postgres.unsetConnectionEnvVars | default dict) }}
           - name: TYK_DB_STORAGE_UPTIME_CONNECTIONSTRING
             valueFrom:
               secretKeyRef:
                 name: {{ include "tyk-dashboard.pg_connection_string_secret_name" . }}
                 key: {{ include "tyk-dashboard.pg_connection_string_secret_key" . }}
+          {{- end }}
           {{ else }}
           - name: TYK_DB_STORAGE_MAIN_TYPE
             value: "mongo"

--- a/components/tyk-dashboard/values.yaml
+++ b/components/tyk-dashboard/values.yaml
@@ -90,6 +90,16 @@ global:
     #   name: ""
     #   keyName: ""
 
+    # If needed you can unset some of the postgres connection related environment variables by providing them here.
+    # Beware that this may break database connectivity.
+    # unsetConnectionEnvVars:
+    #   - TYK_DB_STORAGE_MAIN_TYPE
+    #   - TYK_DB_STORAGE_MAIN_CONNECTIONSTRING
+    #   - TYK_DB_STORAGE_ANALYTICS_TYPE
+    #   - TYK_DB_STORAGE_ANALYTICS_CONNECTIONSTRING
+    #   - TYK_DB_STORAGE_UPTIME_TYPE
+    #   - TYK_DB_STORAGE_UPTIME_CONNECTIONSTRING
+
   redis:
     # The addrs value will allow you to set your Redis addresses. If you are
     # using a redis cluster, you can list the endpoints of the redis instances


### PR DESCRIPTION
## Description
Adds helm value `global.postgres.unsetConnectionEnvVars` which allows user to not set any of the following environment variables
```
TYK_DB_STORAGE_MAIN_TYPE
TYK_DB_STORAGE_MAIN_CONNECTIONSTRING
TYK_DB_STORAGE_ANALYTICS_TYPE
TYK_DB_STORAGE_ANALYTICS_CONNECTIONSTRING
TYK_DB_STORAGE_UPTIME_TYPE
TYK_DB_STORAGE_UPTIME_CONNECTIONSTRING
```

## Related Issue
Closes #403 

## Motivation and Context
As described in the issue using a postgres database with table sharding currently requires `TYK_DB_STORAGE_ANALYTICS_TYPE` to be unset.

## Test Coverage For This Change

## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] Documentation updates or improvements.


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
     - [ ] I have manually updated the README(s)/documentation accordingly.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.