### PR TITLE
fix(dashboard): Bad env variable name for TYK_DB_USESHARDEDANALYTICS

### DIFF
--- a/components/tyk-dashboard/templates/deployment-dashboard.yaml
+++ b/components/tyk-dashboard/templates/deployment-dashboard.yaml
@@ -103,7 +103,7 @@ spec:
             value: "{{ .Values.dashboard.hostConfig.overrideHostname}}"
           - name: "TYK_DB_HOMEDIR"
             value: "{{ .Values.dashboard.homeDir }}"
-          - name: "TYK_DB_USESHARDEDANLAYTICS"
+          - name: "TYK_DB_USESHARDEDANALYTICS"
             value: "{{ .Values.dashboard.useShardedAnalytics }}"
           - name: "TYK_DB_ENABLEANALYTICSCACHE"
             value: "{{ .Values.dashboard.enableAnalyticsCache }}"


### PR DESCRIPTION
## Description
I noticed that the TYK_DB_USESHARDEDANALYTICS was not correctly set in the dashboard deployment template

## Motivation and Context
Fix the env variable TYK_DB_USESHARDEDANLAYTICS
https://github.com/TykTechnologies/tyk-charts/blob/6aefcd2fa6d9ec809d9f5bd13d4e377c8a8d3b22/components/tyk-dashboard/templates/deployment-dashboard.yaml#L106
