### PR TITLE
Revert "[tyk-dashboard] Bad env variable name for TYK_DB_USESHARDEDANALYTICS"

### DIFF
--- a/components/tyk-dashboard/templates/deployment-dashboard.yaml
+++ b/components/tyk-dashboard/templates/deployment-dashboard.yaml
@@ -103,7 +103,7 @@ spec:
             value: "{{ .Values.dashboard.hostConfig.overrideHostname}}"
           - name: "TYK_DB_HOMEDIR"
             value: "{{ .Values.dashboard.homeDir }}"
-          - name: "TYK_DB_USESHARDEDANALYTICS"
+          - name: "TYK_DB_USESHARDEDANLAYTICS"
             value: "{{ .Values.dashboard.useShardedAnalytics }}"
           - name: "TYK_DB_ENABLEANALYTICSCACHE"
             value: "{{ .Values.dashboard.enableAnalyticsCache }}"


### PR DESCRIPTION
Reverts TykTechnologies/tyk-charts#405
@AlexisDuf I am reverting this PR. There is nothing wrong with your contribution, it's just that it needs to be firstly fixed on the dashboard. We have opened an internal ticket to correct this and once it is done, it will be merged. Once again, thanks for your contribution.