### PR TITLE
TT-14957: fix developer portal bootstrap when user refrences their secret

### DIFF
--- a/components/tyk-dev-portal/templates/job-portal.yaml
+++ b/components/tyk-dev-portal/templates/job-portal.yaml
@@ -16,12 +16,19 @@ spec:
         image: curlimages/curl:8.8.0
         env:
         - name: ADMIN_EMAIL
-          value: "{{ .Values.global.adminUser.email  }}"
+          {{ if .Values.global.adminUser.useSecretName }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.adminUser.useSecretName }}
+              key: adminUserEmail
+          {{ else }}
+          value: {{ .Values.global.adminUser.email | quote }}
+          {{ end }}
         - name: ADMIN_PASSWORD
           {{ if .Values.global.adminUser.useSecretName }}
           valueFrom:
             secretKeyRef:
-              name: secrets-{{ include "tyk-dev-portal.fullname" . }}
+              name: {{ .Values.global.adminUser.useSecretName }}
               key: adminUserPassword
           {{ else }}
           value: {{ .Values.global.adminUser.password | quote }}


### PR DESCRIPTION


## Description
<!-- Describe your changes in detail -->
```
This change fixes a bug that occurred when a user specified a custom Kubernetes secret via `useSecretName` in their `values.yaml` file while bootstrapping the developer portal.  

Previously, the Helm chart ignored the provided secret name and defaulted to referencing an internal secret. 
This fix ensures that the chart correctly references the user-defined secret for both `ADMIN_EMAIL` and `ADMIN_PASSWORD` when `useSecretName` is set.  
```

## Related Issue
https://tyktech.atlassian.net/browse/TT-14957
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## Test Coverage For This Change
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] Documentation updates or improvements.


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
     - [ ] I have manually updated the README(s)/documentation accordingly.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.