### PR TITLE
[TT-15362] fixed contianerSecurityContext fields being misplaced

### DIFF
--- a/components/tyk-bootstrap/templates/bootstrap-post-install.yaml
+++ b/components/tyk-bootstrap/templates/bootstrap-post-install.yaml
@@ -43,6 +43,10 @@ spec:
       affinity:
 {{ toYaml .Values.bootstrap.affinity | indent 8 }}
 {{- end }}
+{{- if .Values.bootstrap.securityContext }}
+      securityContext:
+{{ toYaml .Values.bootstrap.securityContext | indent 8 }}
+{{- end }}
       containers:
         - name: bootstrap-tyk-post-install
           image: {{ .Values.global.imageRegistry }}{{ .Values.bootstrap.jobs.postInstall.image.repository }}:{{ .Values.bootstrap.jobs.postInstall.image.tag }}

--- a/components/tyk-bootstrap/templates/bootstrap-pre-delete.yaml
+++ b/components/tyk-bootstrap/templates/bootstrap-pre-delete.yaml
@@ -46,6 +46,10 @@ spec:
       affinity:
 {{ toYaml .Values.bootstrap.affinity | indent 8 }}
 {{- end }}
+{{- if .Values.bootstrap.securityContext }}
+      securityContext:
+{{ toYaml .Values.bootstrap.securityContext | indent 8 }}
+{{- end }}
       containers:
         - name: bootstrap-tyk-pre-delete
           image: {{ .Values.global.imageRegistry }}{{ .Values.bootstrap.jobs.preDelete.image.repository }}:{{ .Values.bootstrap.jobs.preDelete.image.tag }}

--- a/components/tyk-bootstrap/templates/bootstrap-pre-install.yaml
+++ b/components/tyk-bootstrap/templates/bootstrap-pre-install.yaml
@@ -42,6 +42,10 @@ spec:
       affinity:
 {{ toYaml .Values.bootstrap.affinity | indent 8 }}
 {{- end }}
+{{- if .Values.bootstrap.securityContext }}
+      securityContext:
+{{ toYaml .Values.bootstrap.securityContext | indent 8 }}
+{{- end }}
       containers:
         - name: bootstrap-tyk-pre-install
           image: {{ .Values.global.imageRegistry }}{{ .Values.bootstrap.jobs.preInstall.image.repository }}:{{ .Values.bootstrap.jobs.preInstall.image.tag }}

--- a/components/tyk-bootstrap/values.yaml
+++ b/components/tyk-bootstrap/values.yaml
@@ -174,6 +174,12 @@ bootstrap:
   # affinity for bootstrap pods assignment
   affinity: {}
 
+  # securityContext values for bootstrap pods. All fields from PodSecurityContext object can be added here.
+  securityContext:
+    runAsUser: 1000
+    fsGroup: 1000
+    runAsNonRoot: true
+
   # containerSecurityContext values for bootstrap containers
   containerSecurityContext:
     runAsNonRoot: true

--- a/tyk-stack/values.yaml
+++ b/tyk-stack/values.yaml
@@ -1145,11 +1145,16 @@ tyk-bootstrap:
     #     readOnly: true
     extraVolumeMounts: []
 
+    # securityContext values for bootstrap pods. All fields from PodSecurityContext object can be added here.
+    securityContext:
+      runAsUser: 1000
+      fsGroup: 1000
+      runAsNonRoot: true
+
     # containerSecurityContext values for bootstrap containers
     containerSecurityContext:
       runAsNonRoot: true
       runAsUser: 1000
-      fsGroup: 1000
       allowPrivilegeEscalation: false
       privileged: false
       readOnlyRootFilesystem: true


### PR DESCRIPTION
he tyk-stack chart's values.yaml file incorrectly placed the fsGroup field in the containerSecurityContext section for the tyk-bootstrap component. In Kubernetes, fsGroup is a pod-level security context field, not a container-level one. This caused the pre-install job to fail with an error about an unknown field.

## Description
<!-- Describe your changes in detail -->

## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## Test Coverage For This Change
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] Documentation updates or improvements.


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [ ] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
     - [ ] I have manually updated the README(s)/documentation accordingly.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.