### PR TITLE
fix(tyk-pump): allow override of MONGOAGGREGATE_META_COLLECTIONNAME via values

### DIFF
--- a/components/tyk-pump/templates/deployment-pmp.yaml
+++ b/components/tyk-pump/templates/deployment-pmp.yaml
@@ -244,7 +244,7 @@ spec:
                 name: {{ include "tyk-pump.mongo_url_secret_name" . }}
                 key: {{ include "tyk-pump.mongo_url_secret_key" . }}
           - name: TYK_PMP_PUMPS_MONGOAGGREGATE_META_COLLECTIONNAME
-            value: "tyk_analytics_pump"
+            value: "{{ default "tyk_analytics_pump" .Values.pump.mongoAggregatePump.collectionName }}"
           - name: TYK_PMP_PUMPS_MONGOAGGREGATE_META_USEMIXEDCOLLECTION
             value: "true"
           - name : TYK_PMP_PUMPS_MONGOAGGREGATE_META_MONGODRIVERTYPE

--- a/components/tyk-pump/values.yaml
+++ b/components/tyk-pump/values.yaml
@@ -344,6 +344,15 @@ pump:
     # collectionName is the name of the collection that will be created and used by the mongo graph pump
     collectionName: "tyk_graph_analytics"
 
+  # mongoAggregatePump configures values to be used to configure tyk mongo aggregate pump.
+  mongoAggregatePump:
+    # collectionName is the name of the collection used by the mongo aggregate pump.
+    # When empty, defaults to "tyk_analytics_pump" (preserved for backward
+    # compatibility — set this to "tyk_analytics_aggregates" to write rollups
+    # to a dedicated aggregate collection instead of mixing them with the raw
+    # analytics collection).
+    collectionName: ""
+
   # We usually recommend not to specify default resources and to leave this
   # as a conscious choice for the user. This also increases chances charts
   # run on environments with little resources, such as Minikube. If you do


### PR DESCRIPTION
## Description

Adds `pump.mongoAggregatePump.collectionName` so operators can configure the mongo-pump-aggregate target collection through values rather than working around the hardcoded `tyk_analytics_pump` literal via `pump.extraEnvs` (which produces a duplicate env entry on the rendered Pod and is fragile under ServerSideApply / strategic-merge reorders).

Follows the existing `pump.mongoGraphPump.collectionName` precedent.

## Related Issue

Closes #489

## Motivation and Context

Currently `components/tyk-pump/templates/deployment-pmp.yaml` (~line 246) hardcodes:

```yaml
- name: TYK_PMP_PUMPS_MONGOAGGREGATE_META_COLLECTIONNAME
  value: "tyk_analytics_pump"
```

with no values key to override it. The only workaround is `pump.extraEnvs`, which produces duplicate env keys — benign today under strategic-merge (last-write-wins) but rejected by ServerSideApply and undefined under strategic-merge reorders. Full repro + analysis in #489.

This change is additive: the default value is preserved (`tyk_analytics_pump`), so existing installations see no behavior change.

## Test Coverage For This Change

- `helm lint ./components/tyk-pump` passes.
- `helm template ./components/tyk-pump --set 'pump.backend={mongo,prometheus}'` renders `tyk_analytics_pump` (default preserved, no behavior change).
- `helm template ./components/tyk-pump --set 'pump.backend={mongo,prometheus}' --set pump.mongoAggregatePump.collectionName=tyk_analytics_aggregates` renders `tyk_analytics_aggregates` (override works).
- Raw mongo pump (`TYK_PMP_PUMPS_MONGO_META_COLLECTIONNAME`) unchanged in both cases.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] Documentation updates or improvements.

## Checklist

- [x] Pull request opened from a topic branch on a fork (not `master`).
- [x] Pull request targets the repo's primary branch.
- [ ] My change requires a change to the documentation.
  - n/a — the neighbouring `mongoGraphPump.collectionName` precedent is also undocumented in `components/tyk-pump/README.md`. Happy to add docs in a follow-up if maintainers prefer.
- [ ] I have added tests to cover my changes.
  - n/a — no `helm-unittest` target exists for `components/tyk-pump` (only `tyk-stack` is covered today). Happy to add unit tests if maintainers would like.
- [x] All new and existing tests passed (`helm lint`, `helm template` rendering checks).